### PR TITLE
fix NoSuchElementException when no comments

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.ghprb;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHPullRequest;
 
@@ -43,11 +44,14 @@ public class GhprbPullRequest{
 		repo = ghprbRepo;
 		if(updated.compareTo(pr.getUpdatedAt()) < 0){
 			System.out.println("Pull request builder: pr #" + id + " Updated " + pr.getUpdatedAt());
-			List<GHIssueComment> comments = pr.getComments();
-			for(GHIssueComment comment : comments){
-				if(updated.compareTo(comment.getUpdatedAt()) < 0){
-					checkComment(comment);
+			try {
+				List<GHIssueComment> comments = pr.getComments();
+				for(GHIssueComment comment : comments){
+					if(updated.compareTo(comment.getUpdatedAt()) < 0){
+						checkComment(comment);
+					}
 				}
+			} catch (NoSuchElementException e) {
 			}
 			if(!head.equals(pr.getHead().getSha())){
 				head = pr.getHead().getSha();


### PR DESCRIPTION
Fixes the following error when looking on a new pull requests with
no comments yet:

Sep 9, 2012 2:27:10 PM hudson.triggers.Trigger checkTriggers
WARNING: org.jenkinsci.plugins.ghprb.GhprbTrigger.run() failed for xxx
java.util.NoSuchElementException
        at org.kohsuke.github.Requester$1.next(Requester.java:212)
        at org.kohsuke.github.PagedIterator.fetch(PagedIterator.java:42)
        at org.kohsuke.github.PagedIterator.nextPage(PagedIterator.java:57)
        at org.kohsuke.github.PagedIterable.asList(PagedIterable.java:20)
        at org.kohsuke.github.GHIssue.getComments(GHIssue.java:184)
        at org.jenkinsci.plugins.ghprb.GhprbPullRequest.check(GhprbPullRequest.java:46)
        at org.jenkinsci.plugins.ghprb.GhprbRepo.check(GhprbRepo.java:60)
        at org.jenkinsci.plugins.ghprb.GhprbTrigger.run(GhprbTrigger.java:92)
        at hudson.triggers.Trigger.checkTriggers(Trigger.java:259)
        at hudson.triggers.Trigger$Cron.doRun(Trigger.java:207)
        at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:54)
        at java.util.TimerThread.mainLoop(Timer.java:512)
        at java.util.TimerThread.run(Timer.java:462)
