### PR TITLE
Document that "Prune remote branches before build" must not be set

### DIFF
--- a/README
+++ b/README
@@ -48,4 +48,7 @@ Under "Build Triggers", check "Github pull requests builder".
   Set the whitelisted users for this specific job.
 Save to preserve your changes.
 
+Make sure you *DON'T* have "Prune remote branches before build" advanced option
+selected, since it will prune the branch created to test this build.
+
 You are done :)


### PR DESCRIPTION
It will be nice if a better error is thrown or if it wasn't possible to check
"Github pull requests builder" and "Prune remote branches before build" at the
same time.

But having it clearly documented is a step, it would have saved me some time at
least =)
