### PR TITLE
Making optional the comment at the end of the build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuild.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuild.java
@@ -113,7 +113,7 @@ public class GhprbBuild {
 		repo.createCommitStatus(build, state, (merge ? "Merged build finished." : "Build finished."),pull );
 
 		String publishedURL = GhprbTrigger.DESCRIPTOR.getPublishedURL();
-		if (publishedURL != null && !publishedURL.isEmpty()) {
+		if (publishedURL != null && !publishedURL.isEmpty() && repo.isAddCommentWhenBuildFinish()) {
 			String msg;
 			if (state == GHCommitState.SUCCESS) {
 				msg = GhprbTrigger.DESCRIPTOR.getMsgSuccess();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepo.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepo.java
@@ -196,6 +196,10 @@ public class GhprbRepo {
 		return trigger.getDescriptor().getAutoCloseFailedPullRequests();
 	}
 
+	public boolean isAddCommentWhenBuildFinish() {
+		return trigger.getDescriptor().getAddCommentWhenBuildFinish();
+	}
+
 	public String getDefaultComment() {
 		return requestForTestingMessage;
 	}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -168,6 +168,7 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 		private Boolean autoCloseFailedPullRequests = false;
 		private String msgSuccess;
 		private String msgFailure;
+		private Boolean addCommentWhenBuildFinish = true;
 
 		// map of jobs (by their fullName) abd their map of pull requests
 		private Map<String, Map<Integer,GhprbPullRequest>> jobs;
@@ -207,6 +208,7 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 			autoCloseFailedPullRequests = formData.getBoolean("autoCloseFailedPullRequests");
 			msgSuccess = formData.getString("msgSuccess");
 			msgFailure = formData.getString("msgFailure");
+			addCommentWhenBuildFinish = formData.getBoolean("addCommentWhenBuildFinish");
 			save();
 			return super.configure(req,formData);
 		}
@@ -289,6 +291,10 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
 		public String getMsgSuccess() {
 			return msgSuccess;
+		}
+
+		public Boolean getAddCommentWhenBuildFinish() {
+			return addCommentWhenBuildFinish;
 		}
 
 		public String getMsgFailure() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -47,6 +47,9 @@
       <f:entry title="${%Access Token}" field="accessToken">
         <f:password />
       </f:entry>
+      <f:entry title="${%Add comment when build finish?}" field="addCommentWhenBuildFinish">
+        <f:checkbox />
+      </f:entry>
       <f:entry title="${%Default success message}" field="msgSuccess">
         <f:textarea default="Test PASSED!"/>
       </f:entry>


### PR DESCRIPTION
In our workflow we prefer to relay only in the status of the pull request instead of adding comments to it. 

So I've added an option to activate and deactivate the comment that's done when the build finish, by default is activated. 

Should I have used the boolean of use comments when status fail?
