### PR TITLE
Added per job trigger phrase comments 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -21,6 +21,7 @@ public class Ghprb {
 	private HashSet<String>       admins;
 	private HashSet<String>       whitelisted;
 	private HashSet<String>       organisations;
+	private String                triggerPhrase;
 	private GhprbTrigger          trigger;
 	private GhprbRepository       repository;
 	private GhprbBuilds           builds;
@@ -31,7 +32,7 @@ public class Ghprb {
 	
 	private final Pattern retestPhrasePattern;
 	private final Pattern whitelistPhrasePattern;
-	private final Pattern oktotestPhrasePattern;
+	private final Pattern oktotestPhrasePattern;	
 
 	private Ghprb(){
 		retestPhrasePattern = Pattern.compile(GhprbTrigger.getDscp().getRetestPhrase());
@@ -92,6 +93,14 @@ public class Ghprb {
 	public boolean isOktotestPhrase(String comment){
 		return oktotestPhrasePattern.matcher(comment).matches();
 	}
+	
+	public boolean isTriggerPhrase(String comment){
+		return !triggerPhrase.equals("") && comment.contains(triggerPhrase);
+	}
+	
+	public boolean ifOnlyTriggerPhrase() {
+		return trigger.getOnlyTriggerPhrase();
+	}
 
 	public boolean isWhitelisted(String username){
 		return trigger.getPermitAll()
@@ -136,7 +145,8 @@ public class Ghprb {
 			gml.whitelisted.remove("");
 			gml.organisations = new HashSet<String>(Arrays.asList(trigger.getOrgslist().split("\\s+")));
 			gml.organisations.remove("");
-
+			gml.triggerPhrase = trigger.getTriggerPhrase();
+			
 			return this;
 		}
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -41,7 +41,9 @@ public class GhprbPullRequest{
 
 		if(helper.isWhitelisted(author)){
 			accepted = true;
-			shouldRun = true;
+			if(!helper.ifOnlyTriggerPhrase()) {
+				shouldRun = true;
+			}
 		}else{
 			logger.log(Level.INFO, "Author of #{0} {1} on {2} not in whitelist!", new Object[]{id, author, reponame});
 			repo.addComment(id, GhprbTrigger.getDscp().getRequestForTestingPhrase());
@@ -116,7 +118,7 @@ public class GhprbPullRequest{
 		}
 
 		head = sha;
-		if(accepted){
+		if(!ml.ifOnlyTriggerPhrase() && accepted){
 			shouldRun = true;
 		}
 		return true;
@@ -132,22 +134,31 @@ public class GhprbPullRequest{
 				ml.addWhitelist(author);
 			}
 			accepted = true;
-			shouldRun = true;
+			if (!ml.ifOnlyTriggerPhrase()) {
+				shouldRun = true;
+			}
 		}
 
 		// ok to test
-		if(ml.isOktotestPhrase(body) && ml.isAdmin(sender)){
+		if (ml.isOktotestPhrase(body) && ml.isAdmin(sender)){
 			accepted = true;
-			shouldRun = true;
+			if (!ml.ifOnlyTriggerPhrase()) {
+				shouldRun = true;
+			}
 		}
 
 		// test this please
-		if (ml.isRetestPhrase(body)){
+		if (ml.isRetestPhrase(body) && !ml.ifOnlyTriggerPhrase()){
 			if(ml.isAdmin(sender)){
 				shouldRun = true;
 			}else if(accepted && ml.isWhitelisted(sender) ){
 				shouldRun = true;
 			}
+		}
+		
+		// trigger phrase
+		if (ml.isTriggerPhrase(body) && ml.isWhitelisted(sender)){
+			shouldRun = true;
 		}
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -40,6 +40,8 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 	private       String whitelist;
 	private final String orgslist;
 	private final String cron;
+	private final String triggerPhrase;
+	private final Boolean onlyTriggerPhrase;
 	private final Boolean useGitHubHooks;
 	private final Boolean permitAll;
 	private Boolean autoCloseFailedPullRequests;
@@ -47,12 +49,15 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 	transient private Ghprb ml;
 
 	@DataBoundConstructor
-	public GhprbTrigger(String adminlist, String whitelist, String orgslist, String cron, Boolean useGitHubHooks, Boolean permitAll, Boolean autoCloseFailedPullRequests) throws ANTLRException{
+	public GhprbTrigger(String adminlist, String whitelist, String orgslist, String cron, String triggerPhrase,
+			Boolean onlyTriggerPhrase, Boolean useGitHubHooks, Boolean permitAll, Boolean autoCloseFailedPullRequests) throws ANTLRException{
 		super(cron);
 		this.adminlist = adminlist;
 		this.whitelist = whitelist;
 		this.orgslist = orgslist;
 		this.cron = cron;
+		this.triggerPhrase = triggerPhrase;
+		this.onlyTriggerPhrase = onlyTriggerPhrase;
 		this.useGitHubHooks = useGitHubHooks;
 		this.permitAll = permitAll;
 		this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
@@ -152,6 +157,17 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
 	public String getCron() {
 		return cron;
+	}
+	
+	public String getTriggerPhrase() {
+		if(triggerPhrase == null){
+			return "";
+		}
+		return triggerPhrase;
+	}
+	
+	public Boolean getOnlyTriggerPhrase() {
+		return onlyTriggerPhrase != null && onlyTriggerPhrase;
 	}
 
 	public Boolean getUseGitHubHooks() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -6,8 +6,14 @@
     <f:checkbox />
   </f:entry>
   <f:advanced>
+	<f:entry title="${%Trigger phrase}" field="triggerPhrase">
+	  <f:textbox />
+	</f:entry>
+	<f:entry title="Only use trigger phrase for build triggering" field="onlyTriggerPhrase">
+	  <f:checkbox />
+	</f:entry>
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
-		<f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
+	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>
 	<f:entry title="${%Crontab line}" field="cron">
 	  <f:textbox default="${descriptor.cron}"/>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-onlyTriggerPhrase.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-onlyTriggerPhrase.html
@@ -1,0 +1,4 @@
+<div>
+	When checked, only commenting the trigger phrase in the pull request will trigger a build.
+	All other methods of triggering a pull request build are disabled.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-triggerPhrase.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-triggerPhrase.html
@@ -1,0 +1,3 @@
+<div>
+	When filled, commenting this phrase in the pull request will trigger a build.
+</div>


### PR DESCRIPTION
To allow for more job level control for when there are multiple Jenkins jobs per repository and its pull requests.  
An user can now trigger a specific job for a pull request build when ready and done with commit by commenting the specific job's set trigger phrase in the pull request.
Also added checkbox option so that only commenting the trigger phrase will build the job, useful for building long costly jobs only when desired.
