### PR TITLE
expose 'source' branch of pull requests from GitHub

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -39,7 +39,7 @@ public class GhprbBuilds {
 			sb.append(" Build triggered.");
 		}
 
-		GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getAuthorEmail(), pr.getTitle());
+		GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getBranch(), pr.getTarget(), pr.getAuthorEmail(), pr.getTitle());
 
 		QueueTaskFuture<?> build = trigger.startJob(cause);
 		if(build == null){

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
@@ -11,14 +11,16 @@ public class GhprbCause extends Cause{
 	private final String commit;
 	private final int pullID;
 	private final boolean merged;
+	private final String sourceBranch;
 	private final String targetBranch;
 	private final String authorEmail;
 	private final String title;
 
-	public GhprbCause(String commit, int pullID, boolean merged, String targetBranch, String authorEmail, String title){
+	public GhprbCause(String commit, int pullID, boolean merged, String sourceBranch, String targetBranch, String authorEmail, String title){
 		this.commit = commit;
 		this.pullID = pullID;
 		this.merged = merged;
+		this.sourceBranch = sourceBranch;
 		this.targetBranch = targetBranch;
 		this.authorEmail = authorEmail;
 		this.title = title;
@@ -39,6 +41,10 @@ public class GhprbCause extends Cause{
 
 	public int getPullID(){
 		return pullID;
+	}
+
+	public String getSourceBranch() {
+		return sourceBranch;
 	}
 
 	public String getTargetBranch() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -21,6 +21,7 @@ public class GhprbPullRequest{
 	private String head;
 	private boolean mergeable;
 	private String reponame;
+	private String branch;
 	private String target;
 	private String authorEmail;
 
@@ -39,6 +40,7 @@ public class GhprbPullRequest{
 		title = pr.getTitle();
 		author = pr.getUser();
 		reponame = repo.getName();
+		branch = pr.getHead().getRef();
 		target = pr.getBase().getRef();
 		obtainAuthorEmail(pr);
 
@@ -262,6 +264,10 @@ public class GhprbPullRequest{
 
 	public boolean isMergeable() {
 		return mergeable;
+	}
+
+	public String getBranch() {
+		return branch;
 	}
 
 	public String getTarget(){

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -106,6 +106,7 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 		values.add(new StringParameterValue("ghprbActualCommit",cause.getCommit()));
 		final StringParameterValue pullIdPv = new StringParameterValue("ghprbPullId",String.valueOf(cause.getPullID()));
 		values.add(pullIdPv);
+		values.add(new StringParameterValue("ghprbSourceBranch", String.valueOf(cause.getSourceBranch())));
 		values.add(new StringParameterValue("ghprbTargetBranch",String.valueOf(cause.getTargetBranch())));
 		// it's possible the GHUser doesn't have an associated email address
 		values.add(new StringParameterValue("ghprbPullAuthorEmail",cause.getAuthorEmail() != null ? cause.getAuthorEmail() : ""));


### PR DESCRIPTION
With this pull request, source branch name is exposed.
Then multi-repo project knows the branches should be.
