### PR TITLE
Add option to only add a comment on a failed build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -47,6 +47,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     private String whitelist;
     private Boolean autoCloseFailedPullRequests;
     private List<GhprbBranch> whiteListTargetBranches;
+    private final Boolean commentOnlyOnFailure;
     private transient Ghprb helper;
 
     @DataBoundConstructor
@@ -59,7 +60,8 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         Boolean useGitHubHooks,
                         Boolean permitAll,
                         Boolean autoCloseFailedPullRequests,
-                        List<GhprbBranch> whiteListTargetBranches) throws ANTLRException {
+                        List<GhprbBranch> whiteListTargetBranches,
+                        Boolean commentOnlyOnFailure) throws ANTLRException {
         super(cron);
         this.adminlist = adminlist;
         this.whitelist = whitelist;
@@ -71,6 +73,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.permitAll = permitAll;
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.whiteListTargetBranches = whiteListTargetBranches;
+        this.commentOnlyOnFailure = commentOnlyOnFailure;
     }
 
     public static GhprbTrigger extractTrigger(AbstractProject p) {
@@ -289,6 +292,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         private String msgSuccess = "Test PASSed.";
         private String msgFailure = "Test FAILed.";
         private List<GhprbBranch> whiteListTargetBranches;
+        private Boolean commentOnlyOnFailure;
         private transient GhprbGitHub gh;
         // map of jobs (by their fullName) abd their map of pull requests
         private Map<String, ConcurrentMap<Integer, GhprbPullRequest>> jobs;
@@ -329,6 +333,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             autoCloseFailedPullRequests = formData.getBoolean("autoCloseFailedPullRequests");
             msgSuccess = formData.getString("msgSuccess");
             msgFailure = formData.getString("msgFailure");
+            commentOnlyOnFailure = formData.getBoolean("commentOnlyOnFailure");
             save();
             gh = new GhprbGitHub();
             return super.configure(req, formData);
@@ -431,6 +436,10 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
         public boolean isUseComments() {
             return (useComments != null && useComments);
+        }
+
+        public boolean isCommentOnlyOnFailure() {
+            return commentOnlyOnFailure != null && commentOnlyOnFailure;
         }
 
         public GhprbGitHub getGitHub() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -44,5 +44,8 @@
         </table>
       </f:repeatable>
     </f:entry>
+    <f:entry title="Only add a comment on failed builds" field="commentOnlyOnFailure">
+        <f:checkbox/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-commentOnlyOnFailure.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-commentOnlyOnFailure.html
@@ -1,0 +1,4 @@
+<div>
+	When checked, <em>GitHub Pull Request Builder</em> will only add a comment
+	to the pull request when a built failed.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -106,7 +106,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, false
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = provideConfiguration();
@@ -140,7 +140,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, false
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -168,7 +168,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, false
         );
 
         given(commitPointer.getSha()).willReturn("sha");
@@ -252,6 +252,7 @@ public class GhprbIT {
         jsonObject.put("autoCloseFailedPullRequests", "false");
         jsonObject.put("msgSuccess", "Success");
         jsonObject.put("msgFailure", "Failure");
+        jsonObject.put("commentOnlyOnFailure", "false");
 
         return jsonObject;
     }


### PR DESCRIPTION
This makes it possible to have the plugin only add a comment when a build fails. 
