### PR TITLE
[FIXED JENKINS-22550] Properly delegate to web UI of TimerTrigger.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -8,7 +8,6 @@ import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.RevisionParameterAction;
 import hudson.plugins.git.util.BuildData;
-import hudson.triggers.TimerTrigger;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
@@ -281,7 +280,8 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         private String whitelistPhrase = ".*add\\W+to\\W+whitelist.*";
         private String okToTestPhrase = ".*ok\\W+to\\W+test.*";
         private String retestPhrase = ".*test\\W+this\\W+please.*";
-        private String cron = "*/5 * * * *";
+        // TODO what is this for? seems to be unused (compared to instance field of actual Trigger)
+        private String cron = "H/5 * * * *";
         private Boolean useComments = false;
         private int logExcerptLines = 0;
         private String unstableAs = GHCommitState.FAILURE.name();
@@ -339,10 +339,6 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                 return FormValidation.error("GitHub username may only contain alphanumeric characters or dashes and cannot begin with a dash. Separate them with whitespaces.");
             }
             return FormValidation.ok();
-        }
-
-        public FormValidation doCheckCron(@QueryParameter String value) {
-            return (new TimerTrigger.DescriptorImpl().doCheckSpec(value));
         }
 
         public FormValidation doCheckServerAPIUrl(@QueryParameter String value) {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -18,8 +18,8 @@
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>
-	<f:entry title="${%Crontab line}" field="cron">
-	  <f:textbox default="${descriptor.cron}"/>
+	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
+	  <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
 	</f:entry>
 	<f:entry title="${%White list}" field="whitelist">
 	  <f:textarea />

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -41,8 +41,8 @@
       <f:entry title="${%Test phrase}" field="retestPhrase">
         <f:textbox default=".*test\W+this\W+please.*"/>
       </f:entry>
-      <f:entry title="${%Crontab line}" field="cron">
-        <f:textbox default="*/5 * * * *"/>
+      <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
+        <f:textbox default="H/5 * * * *" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
       </f:entry>
       <f:entry title="${%Default success message}" field="msgSuccess">
         <f:textarea default="Test PASSed."/>


### PR DESCRIPTION
[JENKINS-22550](https://issues.jenkins-ci.org/browse/JENKINS-22550): incompatibility in Jenkins core only matters if you are directly calling `@WebMethod`s from outside, whereas the intended form of reuse is as URLs. Restores compatibility with cores before and after https://github.com/jenkinsci/jenkins/commit/f97b5b33b0754532b945340cdee4b6ea1d2f6ba4; offers more advanced UI when using the newer core; shows help; and also switches to hash-balanced scheduled by default.

You may also want to switch to `f:textarea`, which is what `Trigger.spec` normally is shown as.
