### PR TITLE
Adding the ability to skip updating the PR with a comment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.14-SNAPSHOT</version>
+    <version>1.13-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.13-SNAPSHOT</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -103,7 +103,7 @@ public class GhprbBuilds {
         repo.createCommitStatus(build, state, (c.isMerged() ? "Merged build finished." : "Build finished."), c.getPullID());
 
         String publishedURL = GhprbTrigger.getDscp().getPublishedURL();
-        if (publishedURL != null && !publishedURL.isEmpty()) {
+        if (publishedURL != null && !publishedURL.isEmpty() && !trigger.getSkipCommentMessage()) {
             StringBuilder msg = new StringBuilder();
 
             if (state == GHCommitState.SUCCESS) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -45,6 +45,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     private final Boolean permitAll;
     private String whitelist;
     private Boolean autoCloseFailedPullRequests;
+    private Boolean skipCommentMessage;
     private List<GhprbBranch> whiteListTargetBranches;
     private transient Ghprb helper;
 
@@ -58,6 +59,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         Boolean useGitHubHooks,
                         Boolean permitAll,
                         Boolean autoCloseFailedPullRequests,
+						Boolean skipCommentMessage,
                         List<GhprbBranch> whiteListTargetBranches) throws ANTLRException {
         super(cron);
         this.adminlist = adminlist;
@@ -70,6 +72,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.permitAll = permitAll;
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.whiteListTargetBranches = whiteListTargetBranches;
+		this.skipCommentMessage = skipCommentMessage;
     }
 
     public static GhprbTrigger extractTrigger(AbstractProject p) {
@@ -239,6 +242,10 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         } else {
             return autoCloseFailedPullRequests;
         }
+    }
+
+    public Boolean getSkipCommentMessage() {
+        return skipCommentMessage != null && skipCommentMessage;
     }
 
     public List<GhprbBranch> getWhiteListTargetBranches() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -18,7 +18,7 @@
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>
-    <f:entry title="${%Skip adding a comment to pull request}" field="skipCommentMessage">
+    <f:entry title="${%Never comment on the pull request}" field="skipCommentMessage">
       <f:checkbox />
     </f:entry>
 	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -18,6 +18,9 @@
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>
+    <f:entry title="${%Skip adding a comment to pull request}" field="skipCommentMessage">
+      <f:checkbox />
+    </f:entry>
 	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
 	  <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
 	</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-skipCommentMessage.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-skipCommentMessage.html
@@ -1,0 +1,3 @@
+<div>
+	Enabling this option will overwrite the setting in the global configuration on posting comments to pull request.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -106,7 +106,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = provideConfiguration();
@@ -133,6 +133,7 @@ public class GhprbIT {
         // THEN
         Thread.sleep(65000);
         assertThat(project.getBuilds().size()).isEqualTo(1);
+        assertThat(project.getBuilds().size()).isEqualTo(1);
     }
 
     @Test
@@ -140,7 +141,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -168,7 +169,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
 
         given(commitPointer.getSha()).willReturn("sha");


### PR DESCRIPTION
We've felt the need to be able to override the default comment on pull requests and modified the ghpr plugin. Please let us know what we can do to get this merged.