### PR TITLE
Build guidelines in comment on github from commentinfo.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ build.
 
 A new build can also be started with a comment: ``retest this please``.
 
+You can extend standard build comment message on github 
+creating ${WORKSPACE}/commentinfo.md file from shell console or any other
+jenkins plugin. Contents of that file will be added to comment at GitHUB.
+This is usefull for posting some build dependent urls for users without
+access to jenkins UI console.
+
 Jobs can be configured to only build if a matching comment is added to a pull request.  For instance, if you have two job you want to run against a pull request,
 a smoke test job and a full test job, you can configure the full test job to only run if someone adds the comment ``full test please`` on the pull request.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.532</version>
+        <version>1.570</version>
     </parent>
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.13-SNAPSHOT</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Scanner;
+import java.io.File;
 
 /**
  * @author janinko
@@ -106,12 +108,23 @@ public class GhprbBuilds {
         if (publishedURL != null && !publishedURL.isEmpty()) {
             StringBuilder msg = new StringBuilder();
 
+            msg.append("Build guidelines: \n--------------\n");
+            String commentinfo = "";
+            String commentinfopath = build.getModuleRoot().toString() + "/commentinfo.md";
+            try {
+            	commentinfo = new Scanner(new File(commentinfopath), "UTF-8" ).useDelimiter("\\A").next();
+            }
+            catch (Exception e){
+            	commentinfo = "File: " + commentinfopath + " not found";
+            }            
+            msg.append(commentinfo);
+            msg.append("\n--------------\n");
             if (state == GHCommitState.SUCCESS) {
                 msg.append(GhprbTrigger.getDscp().getMsgSuccess());
             } else {
                 msg.append(GhprbTrigger.getDscp().getMsgFailure());
             }
-            msg.append("\nRefer to this link for build results: ");
+            msg.append("\nRefer to this link for build results (access rights to CI server needed): \n");
             msg.append(publishedURL).append(build.getUrl());
 
             int numLines = GhprbTrigger.getDscp().getlogExcerptLines();
@@ -139,7 +152,6 @@ public class GhprbBuilds {
 
             try {
                 GHPullRequest pr = repo.getPullRequest(c.getPullID());
-
                 if (pr.getState().equals(GHIssueState.OPEN)) {
                     repo.closePullRequest(c.getPullID());
                 }


### PR DESCRIPTION
Extending standard comment at github from builder.

This is an example from console

``` sh
echo "This is a guideline" > ${WORKSPACE}/commentinfo.md
```
