### PR TITLE
Add information about failed tests to pull request comment

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -25,8 +25,6 @@ import java.util.logging.Logger;
 /**
  * @author janinko
  */
-//Editied by Quin Rogers
-
 public class GhprbBuilds {
     private static final Logger logger = Logger.getLogger(GhprbBuilds.class.getName());
     private final GhprbTrigger trigger;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -3,13 +3,21 @@ package org.jenkinsci.plugins.ghprb;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Result;
+import hudson.model.User;
 import hudson.model.queue.QueueTaskFuture;
+import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.util.BuildData;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.ChangeLogSet.Entry;
+import hudson.tasks.junit.CaseResult;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.test.TestResult;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -17,6 +25,8 @@ import java.util.logging.Logger;
 /**
  * @author janinko
  */
+//Editied by Quin Rogers
+
 public class GhprbBuilds {
     private static final Logger logger = Logger.getLogger(GhprbBuilds.class.getName());
     private final GhprbTrigger trigger;
@@ -111,8 +121,66 @@ public class GhprbBuilds {
             } else {
                 msg.append(GhprbTrigger.getDscp().getMsgFailure());
             }
+
             msg.append("\nRefer to this link for build results: ");
             msg.append(publishedURL).append(build.getUrl());
+            msg.append("\nBuild Duration: ");
+            msg.append(build.getDurationString());
+            msg.append("\nBuilt on node: ");
+            msg.append(build.getBuiltOnStr());
+
+            //If the name of the node name was empty, the node was the master
+            if(build.getBuiltOnStr().equals("")){
+                msg.append("Master");
+            }
+
+            AbstractTestResultAction testResults = build.getTestResultAction();
+            Boolean testResultsFound = (testResults != null);
+            Iterator iterator;
+
+            iterator = build.getChangeSet().iterator();
+            msg.append("\n\n");
+            if(iterator.hasNext()){
+                msg.append("Changes in this build:\n");
+                while(iterator.hasNext()){
+                    ChangeLogSet.Entry clse = (ChangeLogSet.Entry)iterator.next();
+                    msg.append(clse.getMsgEscaped()).append(" by ");
+                    msg.append(clse.getAuthor().getDisplayName()).append(" ");
+                    msg.append(clse.getCommitId()).append("\n");
+                }
+            } else {
+                msg.append("No changes in this build");
+            }
+
+            if(state != GHCommitState.SUCCESS){
+                //if the tests fail and there are test restults, display them
+                if(testResultsFound){
+                    msg.append("\n\n=====Failed Test Information=====\n");
+                    msg.append("\n ```\n");
+
+                    List<TestResult> failedTests = testResults.getFailedTests();
+                    iterator = failedTests.iterator();
+
+                    msg.append("\nNumber of failed tests: ").append(testResults.getFailCount());
+                    msg.append("/").append(testResults.getTotalCount());
+                    msg.append("\nNumber of skipped tests: ").append(testResults.getSkipCount());
+
+                    while(iterator.hasNext()){
+
+                        CaseResult cr = (CaseResult)iterator.next();
+
+                        //subString(12) returns the string after the first 12 letters, which are not needed. They are: "Case Result:"
+                        msg.append("\n\nFailed test: ").append(cr.getTitle().substring(12));
+                        msg.append("\nRuntime: ").append(cr.getDuration()).append(" seconds");
+                        msg.append("\nNumber of consecutive failed builds: ").append(cr.getAge());
+                    }
+
+                    msg.append("\n ```\n");
+                } else {
+                    msg.append("\nNo tests results were found");
+                    logger.log(Level.INFO, "Test results could not be found");
+                }
+            }
 
             int numLines = GhprbTrigger.getDscp().getlogExcerptLines();
             if (state != GHCommitState.SUCCESS && numLines > 0) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -132,7 +132,7 @@ public class GhprbBuilds {
                 msg.append("Master");
             }
 
-            AbstractTestResultAction<?> testResults = build.getTestResultAction();
+            AbstractTestResultAction<?> testResults = build.getAction(AbstractTestResultAction.class);
             Boolean testResultsFound = (testResults != null);
             Iterator iterator;
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -132,7 +132,7 @@ public class GhprbBuilds {
                 msg.append("Master");
             }
 
-            AbstractTestResultAction testResults = build.getTestResultAction();
+            AbstractTestResultAction<?> testResults = build.getTestResultAction();
             Boolean testResultsFound = (testResults != null);
             Iterator iterator;
 
@@ -150,13 +150,13 @@ public class GhprbBuilds {
                 msg.append("No changes in this build");
             }
 
-            if(state != GHCommitState.SUCCESS){
+            if(state != GHCommitState.SUCCESS && trigger.getMentionTestResults()){
                 //if the tests fail and there are test restults, display them
                 if(testResultsFound){
                     msg.append("\n\n=====Failed Test Information=====\n");
                     msg.append("\n ```\n");
 
-                    List<TestResult> failedTests = testResults.getFailedTests();
+                    List<CaseResult> failedTests = testResults.getFailedTests();
                     iterator = failedTests.iterator();
 
                     msg.append("\nNumber of failed tests: ").append(testResults.getFailCount());

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -43,6 +43,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     private final Boolean onlyTriggerPhrase;
     private final Boolean useGitHubHooks;
     private final Boolean permitAll;
+    private final Boolean mentionTestResults;
     private String whitelist;
     private Boolean autoCloseFailedPullRequests;
     private List<GhprbBranch> whiteListTargetBranches;
@@ -59,6 +60,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         Boolean useGitHubHooks,
                         Boolean permitAll,
                         Boolean autoCloseFailedPullRequests,
+                        Boolean mentionTestResults,
                         List<GhprbBranch> whiteListTargetBranches) throws ANTLRException {
         super(cron);
         this.adminlist = adminlist;
@@ -71,6 +73,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.permitAll = permitAll;
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.whiteListTargetBranches = whiteListTargetBranches;
+        this.mentionTestResults = mentionTestResults;
     }
 
     public static GhprbTrigger extractTrigger(AbstractProject p) {
@@ -234,6 +237,11 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     public Boolean getPermitAll() {
         return permitAll != null && permitAll;
     }
+    
+
+	public boolean getMentionTestResults() {
+		return mentionTestResults != null && mentionTestResults;
+	}
 
     public Boolean isAutoCloseFailedPullRequests() {
         if (autoCloseFailedPullRequests == null) {
@@ -477,4 +485,5 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             return whiteListTargetBranches;
         }
     }
+
 }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -18,6 +18,9 @@
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>
+    <f:entry title="${%Mention Jenkins test results in status comment?}" field="mentionTestResults">
+	  <f:checkbox />
+	</f:entry>
 	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
 	  <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
 	</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-mentionTestResults.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-mentionTestResults.html
@@ -1,0 +1,5 @@
+<div>
+	Mention any failed test information in the status comment to the published url.<br />
+	<br />
+	This is for mvn builds, and will add the information from failed tests.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -106,7 +106,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = provideConfiguration();
@@ -140,7 +140,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -168,7 +168,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
 
         given(commitPointer.getSha()).willReturn("sha");


### PR DESCRIPTION
The comment on the pull request now contains information on the changes in that build as well as information on the tests that failed.