### PR TITLE
Add option to allow members of whitelisted organizations to whitelist users/trigger PR tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -129,8 +129,14 @@ public class Ghprb {
                 || isInWhitelistedOrganisation(user);
     }
 
-    public boolean isAdmin(String username) {
-        return admins.contains(username);
+    public boolean isAdmin(GHUser user) {
+        return admins.contains(user.getLogin())
+                || (trigger.getAllowMembersOfWhitelistedOrgsAsAdmin()
+                    && isInWhitelistedOrganisation(user));
+    }
+
+    public boolean isBotUser(GHUser user) {
+        return user != null && user.getLogin().equals(getGitHub().getBotUserLogin());
     }
 
     private boolean isInWhitelistedOrganisation(GHUser user) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
@@ -54,4 +54,13 @@ public class GhprbGitHub {
 		}
 		return orgHasMember;
 	}
+
+	public String getBotUserLogin() {
+		try {
+			return get().getMyself().getLogin();
+		} catch (IOException ex) {
+			logger.log(Level.SEVERE, null, ex);
+			return null;
+		}
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -124,10 +124,18 @@ public class GhprbPullRequestMerge extends Recorder {
 		
 		GHUser triggerSender = cause.getTriggerSender();
 		
+		// ignore comments from bot user, this fixes an issue where the bot would auto-merge
+		// a PR when the 'request for testing' phrase contains the PR merge trigger phrase and
+		// the bot is a member of a whitelisted organisation
+		if (helper.isBotUser(triggerSender)) {
+			logger.println("Comment from bot user " + triggerSender.getLogin() + " ignored.");
+			return false;
+		}
+	
 		boolean merge = true;
 		
 
-		if (isOnlyAdminsMerge() && !helper.isAdmin(triggerSender.getLogin())){
+		if (isOnlyAdminsMerge() && !helper.isAdmin(triggerSender)){
 			merge = false;
 			logger.println("Only admins can merge this pull request, " + triggerSender.getLogin() + " is not an admin.");
 	    	commentOnRequest(

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -44,6 +44,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
     private static final Logger logger = Logger.getLogger(GhprbTrigger.class.getName());
     private final String adminlist;
+    private final Boolean allowMembersOfWhitelistedOrgsAsAdmin;
     private final String orgslist;
     private final String cron;
     private final String triggerPhrase;
@@ -68,7 +69,8 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         Boolean permitAll,
                         Boolean autoCloseFailedPullRequests,
                         String commentFilePath,
-                        List<GhprbBranch> whiteListTargetBranches) throws ANTLRException {
+                        List<GhprbBranch> whiteListTargetBranches,
+                        Boolean allowMembersOfWhitelistedOrgsAsAdmin) throws ANTLRException {
         super(cron);
         this.adminlist = adminlist;
         this.whitelist = whitelist;
@@ -81,6 +83,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.whiteListTargetBranches = whiteListTargetBranches;
         this.commentFilePath = commentFilePath;
+        this.allowMembersOfWhitelistedOrgsAsAdmin = allowMembersOfWhitelistedOrgsAsAdmin;
     }
 
     public static GhprbTrigger extractTrigger(AbstractProject<?, ?> p) {
@@ -232,6 +235,10 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             return "";
         }
         return adminlist;
+    }
+
+    public Boolean getAllowMembersOfWhitelistedOrgsAsAdmin() {
+        return allowMembersOfWhitelistedOrgsAsAdmin != null && allowMembersOfWhitelistedOrgsAsAdmin;
     }
 
     public String getWhitelist() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -30,6 +30,9 @@
 	<f:entry title="${%List of organisations. Their members will be whitelisted.}" field="orgslist">
 	  <f:textarea />
 	</f:entry>
+	<f:entry title="Allow members of whitelisted organisations as admins" field="allowMembersOfWhitelistedOrgsAsAdmin">
+	  <f:checkbox />
+	</f:entry>
     <f:entry title="Build every pull request automatically without asking (Dangerous!)." field="permitAll">
       <f:checkbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-allowMembersOfWhitelistedOrgsAsAdmin.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-allowMembersOfWhitelistedOrgsAsAdmin.html
@@ -1,0 +1,3 @@
+<div>
+  Use this option to allow members of whitelisted organisations to behave like admins, i.e. whitelist users and trigger pull request testing.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -122,7 +122,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, null, false
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = provideConfiguration();
@@ -156,7 +156,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, null, false
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -184,7 +184,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null, null, false
         );
 
         given(commitPointer.getSha()).willReturn("sha");
@@ -236,6 +236,7 @@ public class GhprbIT {
         jsonObject.put("password", "1111");
         jsonObject.put("accessToken", "accessToken");
         jsonObject.put("adminlist", "user");
+        jsonObject.put("allowMembersOfWhitelistedOrgsAsAdmin", "false");
         jsonObject.put("publishedURL", "");
         jsonObject.put("requestForTestingPhrase", "test this");
         jsonObject.put("whitelistPhrase", "");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -37,6 +37,7 @@ import com.coravy.hudson.plugins.github.GithubProjectProperty;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -91,7 +92,7 @@ public class GhprbPullRequestMergeTest {
 	
 	@Before 
 	public void beforeTest() throws Exception {
-		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, null, null));
+		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, null, null, false));
 
 		ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
 		pulls.put(pullId, pullRequest);
@@ -142,6 +143,7 @@ public class GhprbPullRequestMergeTest {
         helper = spy(new Ghprb(project, trigger, pulls));
 		trigger.setHelper(helper);
         given(helper.getRepository()).willReturn(repo);
+		given(helper.isBotUser(any(GHUser.class))).willReturn(false);
 	}
 	
 	@After

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -295,6 +295,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
 
+        verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
         verify(helper).isOktotestPhrase(eq("comment body"));
         verify(helper).isRetestPhrase(eq("comment body"));
@@ -302,7 +303,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
 
@@ -374,14 +375,15 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
 
+        verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("test this please"));
         verify(helper).isOktotestPhrase(eq("test this please"));
         verify(helper).isRetestPhrase(eq("test this please"));
-        verify(helper).isAdmin(eq("login"));
+        verify(helper).isAdmin(eq(ghUser));
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
 
         verify(builds, times(2)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));


### PR DESCRIPTION
This adds a config option to allow members of whitelisted organizations to effectively behave like they were entered into the admin list, which is more practical for organizations with many members.

We are using this at the Mono project since a few days and it seems to work fine :)
