### PR TITLE
replace deprecated method with new one

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
@@ -25,7 +25,7 @@ public class GhprbGitHub {
 				throw e;
 			}
 		} else {
-			gh = GitHub.connect(GhprbTrigger.getDscp().getUsername(), null, GhprbTrigger.getDscp().getPassword());
+			gh = GitHub.connectUsingPassword(GhprbTrigger.getDscp().getUsername(), GhprbTrigger.getDscp().getPassword());
 		}
 	}
 


### PR DESCRIPTION
GitHub.connect() method is deprecated. We should use GitHub.connectUsingPassword() instead.
