### PR TITLE
Added support to mention the author of the PR in the success/failure comment message posted to github.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -39,7 +39,8 @@ public class GhprbBuilds {
             sb.append(" Build triggered.");
         }
 
-        GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getSource(), pr.getAuthorEmail(), pr.getTitle(), pr.getUrl());
+        GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getSource(),
+                pr.getAuthorEmail(), pr.getAuthorUsername(), pr.getTitle(), pr.getUrl());
 
         QueueTaskFuture<?> build = trigger.startJob(cause, repo);
         if (build == null) {
@@ -106,11 +107,18 @@ public class GhprbBuilds {
         if (publishedURL != null && !publishedURL.isEmpty()) {
             StringBuilder msg = new StringBuilder();
 
+            if (trigger.getMentionAuthor()) {
+                msg.append("@");
+                msg.append(c.getAuthorUsername());
+                msg.append(" ");
+            }
+
             if (state == GHCommitState.SUCCESS) {
                 msg.append(GhprbTrigger.getDscp().getMsgSuccess());
             } else {
                 msg.append(GhprbTrigger.getDscp().getMsgFailure());
             }
+
             msg.append("\nRefer to this link for build results: ");
             msg.append(publishedURL).append(build.getUrl());
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
@@ -16,16 +16,19 @@ public class GhprbCause extends Cause{
 	private final String targetBranch;
 	private final String sourceBranch;
 	private final String authorEmail;
+    private final String authorUsername;
 	private final String title;
     private final URL url;
 
-    public GhprbCause(String commit, int pullID, boolean merged, String targetBranch, String sourceBranch, String authorEmail, String title, URL url){
+    public GhprbCause(String commit, int pullID, boolean merged, String targetBranch, String sourceBranch, String authorEmail, String authorUsername,
+                      String title, URL url){
 		this.commit = commit;
 		this.pullID = pullID;
 		this.merged = merged;
 		this.targetBranch = targetBranch;
 		this.sourceBranch = sourceBranch;
 		this.authorEmail = authorEmail;
+        this.authorUsername = authorUsername;
 		this.title = title;
         this.url = url;
 	}
@@ -58,6 +61,10 @@ public class GhprbCause extends Cause{
 	public String getAuthorEmail() {
 		return authorEmail;
 	}
+
+    public String getAuthorUsername() {
+        return authorUsername;
+    }
 
     public URL getUrl() {
         return url;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -33,6 +33,7 @@ public class GhprbPullRequest {
     private String target;
     private String source;
     private String authorEmail;
+    private String authorUsername;
     private URL url;
 
     private boolean shouldRun = false;
@@ -53,6 +54,7 @@ public class GhprbPullRequest {
         source = pr.getHead().getRef();
         url = pr.getUrl();
         obtainAuthorEmail(pr);
+        obtainAuthorUsername(pr);
 
         this.helper = helper;
         this.repo = repo;
@@ -283,6 +285,14 @@ public class GhprbPullRequest {
         }
     }
 
+    private void obtainAuthorUsername(GHPullRequest pr) {
+        try {
+            authorUsername = pr.getUser().getLogin();
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Couldn't obtain author username.", e);
+        }
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof GhprbPullRequest)) {
@@ -321,6 +331,10 @@ public class GhprbPullRequest {
 
     public String getAuthorEmail() {
         return authorEmail;
+    }
+
+    public String getAuthorUsername() {
+        return authorUsername;
     }
 
     public String getTitle() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -40,6 +40,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String orgslist;
     private final String cron;
     private final String triggerPhrase;
+    private final Boolean mentionAuthor;
     private final Boolean onlyTriggerPhrase;
     private final Boolean useGitHubHooks;
     private final Boolean permitAll;
@@ -55,6 +56,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         String orgslist,
                         String cron,
                         String triggerPhrase,
+                        Boolean mentionAuthor,
                         Boolean onlyTriggerPhrase,
                         Boolean useGitHubHooks,
                         Boolean permitAll,
@@ -66,6 +68,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.orgslist = orgslist;
         this.cron = cron;
         this.triggerPhrase = triggerPhrase;
+        this.mentionAuthor = mentionAuthor;
         this.onlyTriggerPhrase = onlyTriggerPhrase;
         this.useGitHubHooks = useGitHubHooks;
         this.permitAll = permitAll;
@@ -221,6 +224,10 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             return "";
         }
         return triggerPhrase;
+    }
+
+    public Boolean getMentionAuthor() {
+        return mentionAuthor;
     }
 
     public Boolean getOnlyTriggerPhrase() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -15,6 +15,9 @@
 	<f:entry title="Only use trigger phrase for build triggering" field="onlyTriggerPhrase">
 	  <f:checkbox />
 	</f:entry>
+	<f:entry title="Mention pull request author in result comment" field="mentionAuthor">
+	  <f:checkbox />
+	</f:entry>
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -106,7 +106,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = provideConfiguration();
@@ -140,7 +140,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -168,7 +168,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
 
         given(commitPointer.getSha()).willReturn("sha");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
@@ -125,6 +125,7 @@ public class GhprbPullRequestTest {
         given(base.getRef()).willReturn("some ref");
         given(pr.getUser()).willReturn(ghUser);
         given(ghUser.getEmail()).willReturn("email");
+        given(ghUser.getLogin()).willReturn("login-name");
 
         // Mocks for GhprbRepository
         given(repo.getName()).willReturn("name");
@@ -135,6 +136,8 @@ public class GhprbPullRequestTest {
 
 
         GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
+        assertThat(ghprbPullRequest.getAuthorUsername()).isEqualTo("login-name");
+
         GhprbRepository ghprbRepository = mock(GhprbRepository.class);
         given(ghprbRepository.getName()).willReturn("name");
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -192,7 +192,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(3)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(8)).getHead();
         verify(ghPullRequest, times(3)).getBase();
@@ -208,7 +208,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
-        verify(ghUser, times(1)).getLogin();
+        verify(ghUser, times(2)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
 
@@ -259,7 +259,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(3)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(8)).getHead();
         verify(ghPullRequest, times(3)).getBase();
@@ -282,7 +282,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(3)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
 
@@ -332,7 +332,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(3)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(8)).getHead();
         verify(ghPullRequest, times(3)).getBase();
@@ -355,7 +355,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(3)).getLogin();
         verifyNoMoreInteractions(ghUser);
 
         verify(builds, times(2)).build(any(GhprbPullRequest.class));


### PR DESCRIPTION
This adds support to include the authors username as a mention in the success or failure message posted as a comment against the PR.