### PR TITLE
Adding an option to disallow committers from approving their own code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.42</version>
+            <version>1.55</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -1,9 +1,7 @@
 package org.jenkinsci.plugins.ghprb;
 
 import com.coravy.hudson.plugins.github.GithubProjectProperty;
-import com.google.common.base.Preconditions;
 import hudson.model.AbstractProject;
-import jenkins.model.Jenkins;
 import org.kohsuke.github.GHUser;
 
 import java.util.*;
@@ -13,7 +11,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.*;
 
 /**
  * @author janinko
@@ -143,5 +140,9 @@ public class Ghprb {
     List<GhprbBranch> getWhiteListTargetBranches() {
         return trigger.getWhiteListTargetBranches();
     }
+
+	public boolean isDisallowOwnCode() {
+		return trigger.getDisallowOwnCode();
+	}
 
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -43,6 +43,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     private final Boolean onlyTriggerPhrase;
     private final Boolean useGitHubHooks;
     private final Boolean permitAll;
+    private Boolean disallowOwnCode;
     private String whitelist;
     private Boolean autoCloseFailedPullRequests;
     private List<GhprbBranch> whiteListTargetBranches;
@@ -58,6 +59,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         Boolean onlyTriggerPhrase,
                         Boolean useGitHubHooks,
                         Boolean permitAll,
+                        Boolean disallowOwnCode,
                         Boolean autoCloseFailedPullRequests,
                         List<GhprbBranch> whiteListTargetBranches) throws ANTLRException {
         super(cron);
@@ -69,6 +71,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.onlyTriggerPhrase = onlyTriggerPhrase;
         this.useGitHubHooks = useGitHubHooks;
         this.permitAll = permitAll;
+        this.disallowOwnCode = disallowOwnCode;
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.whiteListTargetBranches = whiteListTargetBranches;
     }
@@ -233,6 +236,14 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public Boolean getPermitAll() {
         return permitAll != null && permitAll;
+    }
+    
+    public Boolean getDisallowOwnCode() {
+    	return disallowOwnCode != null && disallowOwnCode;
+    }
+    
+    public void setDisallowOwnCode(boolean disallowOwnCode) {
+    	this.disallowOwnCode = disallowOwnCode;
     }
 
     public Boolean isAutoCloseFailedPullRequests() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -18,7 +18,10 @@
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>
-	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
+	<f:entry title="${%Disallow merging your own code?}" field="disallowOwnCode">
+	  <f:checkbox default="${descriptor.disallowOwnCode}"/>
+	</f:entry>  
+    <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
 	  <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
 	</f:entry>
 	<f:entry title="${%White list}" field="whitelist">

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -29,6 +29,9 @@
       <f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
         <f:checkbox />
       </f:entry>
+	  <f:entry title="${%Disallow merging your own code?}" field="disallowOwnCode">
+	    <f:checkbox default="${descriptor.disallowOwnCode}"/>
+	  </f:entry>  
       <f:entry title="${%Request for testing phrase}" field="requestForTestingPhrase">
         <f:textbox default="Can one of the admins verify this patch?"/>
       </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-disallowOwnCode.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-disallowOwnCode.html
@@ -1,0 +1,7 @@
+<div>
+	Disallow merging your own code.
+
+	Pull requests are only allowed to be merged by reviewers.
+	Anyone with code in the pull request will be denied, and
+	a comment will be posted to github reflecting that.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -106,7 +106,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = provideConfiguration();
@@ -140,7 +140,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -168,7 +168,7 @@ public class GhprbIT {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null
         );
 
         given(commitPointer.getSha()).willReturn("sha");
@@ -246,6 +246,7 @@ public class GhprbIT {
         jsonObject.put("retestPhrase", "retest this please");
         jsonObject.put("cron", "*/1 * * * *");
         jsonObject.put("useComments", "true");
+        jsonObject.put("disallowOwnMerge", "false");
         jsonObject.put("logExcerptLines", "0");
         jsonObject.put("unstableAs", "");
         jsonObject.put("testMode", "true");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -146,6 +146,7 @@ public class GhprbRepositoryTest {
 
         verify(helper).ifOnlyTriggerPhrase();
         verify(helper).getWhiteListTargetBranches();
+        verify(helper).isDisallowOwnCode();
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
@@ -205,6 +206,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).isDisallowOwnCode();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
@@ -279,6 +281,7 @@ public class GhprbRepositoryTest {
         verify(helper).isOktotestPhrase(eq("comment body"));
         verify(helper).isRetestPhrase(eq("comment body"));
         verify(helper).isTriggerPhrase(eq("comment body"));
+        verify(helper, times(2)).isDisallowOwnCode();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
@@ -352,6 +355,7 @@ public class GhprbRepositoryTest {
         verify(helper).isOktotestPhrase(eq("test this please"));
         verify(helper).isRetestPhrase(eq("test this please"));
         verify(helper).isAdmin(eq("login"));
+        verify(helper, times(2)).isDisallowOwnCode();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API


### PR DESCRIPTION
Our company needs to implement the policy that a developer cannot merge their own code.  Adding this option allows us to create a build that would only work when triggered and the commentor is listed as Admin and isn't in the commit list.  

I am not sure how to develop the test to mock commits in the pull request, and if someone can point me in the right direction I would be happy to add some tests surrounding it.
