### PR TITLE
[FIXED JENKINS-24592] Support HTTP proxies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.58</version>
+            <version>1.59</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
 
 /**
  * @author janinko
@@ -19,7 +20,11 @@ public class GhprbGitHub {
 		String serverAPIUrl = GhprbTrigger.getDscp().getServerAPIUrl();
 		if(accessToken != null && !accessToken.isEmpty()) {
 			try {
-				gh = GitHub.connectUsingOAuth(serverAPIUrl, accessToken);
+				gh = new GitHubBuilder()
+						.withEndpoint(serverAPIUrl)
+						.withOAuthToken(accessToken)
+						.withConnector(new HttpConnectorWithJenkinsProxy())
+						.build();
 			} catch(IOException e) {
 				logger.log(Level.SEVERE, "Can''t connect to {0} using oauth", serverAPIUrl);
 				throw e;
@@ -28,7 +33,10 @@ public class GhprbGitHub {
 			if (serverAPIUrl.contains("api/v3")) {
 				gh = GitHub.connectToEnterprise(serverAPIUrl, GhprbTrigger.getDscp().getUsername(), GhprbTrigger.getDscp().getPassword());
 			} else {
-				gh = GitHub.connectUsingPassword(GhprbTrigger.getDscp().getUsername(), GhprbTrigger.getDscp().getPassword());
+				gh = new GitHubBuilder()
+						.withPassword(GhprbTrigger.getDscp().getUsername(), GhprbTrigger.getDscp().getPassword())
+						.withConnector(new HttpConnectorWithJenkinsProxy())
+						.build();
 			}
 		}
 	}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/HttpConnectorWithJenkinsProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/HttpConnectorWithJenkinsProxy.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins.ghprb;
+
+import hudson.ProxyConfiguration;
+import org.kohsuke.github.HttpConnector;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class HttpConnectorWithJenkinsProxy implements HttpConnector{
+    public HttpURLConnection connect(URL url) throws IOException {
+        return (HttpURLConnection)ProxyConfiguration.open(url);
+    }
+}


### PR DESCRIPTION
[JENKINS-24592](https://issues.jenkins-ci.org/browse/JENKINS-24592)

This pull request enables the plugin to work behind HTTP proxies.
- TODO
  - [x] [github-api](https://github.com/kohsuke/github-api) 1.59 is released
    - [x] kohsuke/github-api#124
  - [x] [github-api-plugin](https://github.com/jenkinsci/github-api-plugin/) 1.59 is released
  - [x] Remove `-SNAPSHOT` in pom.xml in this pull request
