### PR TITLE
Increase log level of message that is logged if a bot user comment is ignored

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -264,7 +264,7 @@ public class GhprbPullRequest {
         // a user or trigger a build when the 'request for testing' phrase contains the
         // whitelist/trigger phrase and the bot is a member of a whitelisted organisation
         if (helper.isBotUser(sender)) {
-            logger.log(Level.FINEST, "Comment from bot user {0} ignored.", sender);
+            logger.log(Level.INFO, "Comment from bot user {0} ignored.", sender);
             return;
         }
 


### PR DESCRIPTION
FINEST is too low, as can be seen from the confusion in https://github.com/janinko/ghprb/issues/188.

Maybe even raise this to WARNING ?
