### PR TITLE
Making short description more verbose.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
@@ -43,10 +43,21 @@ public class GhprbCause extends Cause{
         this.commitAuthor = commitAuthor;
 	}
 
-	@Override
-	public String getShortDescription() {
-		return "GitHub pull request #" + pullID + " of commit " + commit + (merged? " automatically merged." : ".");
-	}
+    @Override
+    public String getShortDescription() {
+        String[] splitUrl = StringUtils.split(this.url.toString(), '/');
+        String ownerAndRepo = splitUrl[2] + '/' + splitUrl[3];
+
+        return String.format(
+                "%s created pull request a from %s to %s@%s: %s",
+                this.commitAuthor.getName(),
+                this.sourceBranch,
+                ownerAndRepo,
+                this.targetBranch,
+                this.getUrl()
+
+        );
+    }
 
 	public String getCommit() {
 		return commit;


### PR DESCRIPTION
This is an enhancement to solve the issue described in the issue: https://github.com/janinko/ghprb/issues/194

Short description should be more descriptive about the actions being taking by the pull request builder and not mention the phrase "Automatically merged" when no merging has taken place (unless you're referring to the PR branch)