### PR TITLE
Don't set default for job-specific messages

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -527,23 +527,14 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         }
 
         public String getMsgSuccess(AbstractBuild<?, ?> build) {
-        	String msg = msgSuccess;
-            if (msg == null) {
-                msg = "Test PASSed.";
-            }
-            
-        	msg = Ghprb.replaceMacros(build, msg);
+            String msg = msgSuccess;
+            msg = Ghprb.replaceMacros(build, msg);
             return msg;
         }
 
         public String getMsgFailure(AbstractBuild<?, ?> build) {
-        	String msg = msgFailure;
-            if (msg == null) {
-                msg = "Test FAILed.";
-            }
-            
-        	msg = Ghprb.replaceMacros(build, msg);
-            
+            String msg = msgFailure;
+            msg = Ghprb.replaceMacros(build, msg);
             return msg;
         }
 


### PR DESCRIPTION
After these were added, there was no way to turn off commenting.

We don't need to set the default for job-specific status messages, since it's already set at the plugin level.
