### PR TITLE
change message format within github markdown

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -144,7 +144,7 @@ public class GhprbBuilds {
                 msg.append(GhprbTrigger.getDscp().getMsgFailure(build));
             }
 
-            msg.append("\nRefer to this link for build results (access rights to CI server needed):");
+            msg.append("\nRefer to this link for build results (access rights to CI server needed): \n");
             msg.append(generateCustomizedMessage(build));
 
             int numLines = GhprbTrigger.getDscp().getlogExcerptLines();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManager.java
@@ -46,13 +46,11 @@ public class BuildFlowBuildManager extends GhprbBaseBuildManager {
 			JobInvocation jobInvocation = iterator.next();
 
 			sb.append("\n");
-			sb.append("\t");
-			sb.append("[");
+			sb.append("<a href='");
 			sb.append(jobInvocation.getBuildUrl());
-			sb.append("]");
-			sb.append("(");
+			sb.append("'>");
 			sb.append(jobInvocation.getBuildUrl());
-			sb.append(")");
+			sb.append("</a>");
 		}
 
 		return sb.toString();

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
@@ -74,12 +74,11 @@ public class BuildFlowBuildManagerTest extends GhprbITBaseTestCase {
 
 			String jobInvocationBuildUrl = jobInvocation.getBuildUrl();
 
-			expectedUrl.append("\n\t[");
+			expectedUrl.append("\n<a href='");
 			expectedUrl.append(jobInvocationBuildUrl);
-			expectedUrl.append("]");
-			expectedUrl.append("(");
+			expectedUrl.append("'>");
 			expectedUrl.append(jobInvocationBuildUrl);
-			expectedUrl.append(")");
+			expectedUrl.append("</a>");
 
 			count++;
 		}


### PR DESCRIPTION
When I tried to use 'Published Jenkins URL' to see link to results in GitHub comments I see next, GitHub can't display HTML markdown:
Before my changes it looks like this:
![screenshot from 2014-10-13 18 52 02](https://cloud.githubusercontent.com/assets/1260333/4616187/0971b79e-52f1-11e4-96b1-0420f4d8574d.png)
after my changes, that I commited in this PR it looks like -
![screenshot from 2014-10-13 18 51 20](https://cloud.githubusercontent.com/assets/1260333/4616198/1aa35d9c-52f1-11e4-9f3d-2ecb8a21f322.png)
it is clickable.

The reason that GitHub requires markdown for links in format 
![screenshot from 2014-10-13 19 56 00](https://cloud.githubusercontent.com/assets/1260333/4616265/9a0000d6-52f1-11e4-9877-309f56172cad.png)

Tests are passed ok.

```
Tests run: 28, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESSFUL

```
