### PR TITLE
Fix condition where admin can't run tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -24,15 +24,8 @@ public class Ghprb {
     private static final Logger logger = Logger.getLogger(Ghprb.class.getName());
     private static final Pattern githubUserRepoPattern = Pattern.compile("^(http[s]?://[^/]*)/([^/]*)/([^/]*).*");
 
-    private final Set<String> admins;
-    private final Set<String> whitelisted;
-    private final Set<String> organisations;
-    private final String triggerPhrase;
     private final GhprbTrigger trigger;
     private final AbstractProject<?, ?> project;
-    private final Pattern retestPhrasePattern;
-    private final Pattern whitelistPhrasePattern;
-    private final Pattern oktotestPhrasePattern;
     private GhprbRepository repository;
     private GhprbBuilds builds;
 
@@ -52,17 +45,6 @@ public class Ghprb {
         final String repo = m.group(3);
 
         this.trigger = trigger;
-        this.admins = new HashSet<String>(Arrays.asList(trigger.getAdminlist().split("\\s+")));
-        this.admins.remove("");
-        this.whitelisted = new HashSet<String>(Arrays.asList(trigger.getWhitelist().split("\\s+")));
-        this.whitelisted.remove("");
-        this.organisations = new HashSet<String>(Arrays.asList(trigger.getOrgslist().split("\\s+")));
-        this.organisations.remove("");
-        this.triggerPhrase = trigger.getTriggerPhrase();
-
-        retestPhrasePattern = Pattern.compile(trigger.getDescriptor().getRetestPhrase());
-        whitelistPhrasePattern = Pattern.compile(trigger.getDescriptor().getWhitelistPhrase());
-        oktotestPhrasePattern = Pattern.compile(trigger.getDescriptor().getOkToTestPhrase());
 
         this.repository = new GhprbRepository(user, repo, this, pulls);
         this.builds = new GhprbBuilds(trigger, repository);
@@ -77,7 +59,6 @@ public class Ghprb {
 
     public void addWhitelist(String author) {
         logger.log(Level.INFO, "Adding {0} to whitelist", author);
-        whitelisted.add(author);
         trigger.addWhitelist(author);
     }
 
@@ -102,20 +83,60 @@ public class Ghprb {
         builds = null;
     }
 
+    // These used to be stored on the object in the constructor.
+    // But because the object is only instantiated once per PR, configuration would go stale.
+    // Some optimization could be done around re-compiling regex/hash sets, but beyond that we still have to re-pull the text.
+    private Pattern retestPhrasePattern() {
+        return Pattern.compile(trigger.getDescriptor().getRetestPhrase());
+    }
+
+    private Pattern whitelistPhrasePattern() {
+        return Pattern.compile(trigger.getDescriptor().getWhitelistPhrase());
+    }
+
+    private Pattern oktotestPhrasePattern() {
+        return Pattern.compile(trigger.getDescriptor().getOkToTestPhrase());
+    }
+
+    private String triggerPhrase() {
+        return trigger.getTriggerPhrase();
+    }
+
+    private HashSet<String> admins() {
+        HashSet<String> adminList;
+        adminList = new HashSet<String>(Arrays.asList(trigger.getAdminlist().split("\\s+")));
+        adminList.remove("");
+        return adminList;
+    }
+
+    private HashSet<String> whitelisted() {
+        HashSet<String> whitelistedList;
+        whitelistedList = new HashSet<String>(Arrays.asList(trigger.getWhitelist().split("\\s+")));
+        whitelistedList.remove("");
+        return whitelistedList;
+    }
+
+    private HashSet<String> organisations() {
+        HashSet<String> organisationsList;
+        organisationsList = new HashSet<String>(Arrays.asList(trigger.getOrgslist().split("\\s+")));
+        organisationsList.remove("");
+        return organisationsList;
+    }
+
     public boolean isRetestPhrase(String comment) {
-        return retestPhrasePattern.matcher(comment).matches();
+        return retestPhrasePattern().matcher(comment).matches();
     }
 
     public boolean isWhitelistPhrase(String comment) {
-        return whitelistPhrasePattern.matcher(comment).matches();
+        return whitelistPhrasePattern().matcher(comment).matches();
     }
 
     public boolean isOktotestPhrase(String comment) {
-        return oktotestPhrasePattern.matcher(comment).matches();
+        return oktotestPhrasePattern().matcher(comment).matches();
     }
 
     public boolean isTriggerPhrase(String comment) {
-        return !triggerPhrase.equals("") && comment.contains(triggerPhrase);
+        return !triggerPhrase().equals("") && comment.contains(triggerPhrase());
     }
 
     public boolean ifOnlyTriggerPhrase() {
@@ -124,13 +145,13 @@ public class Ghprb {
 
     public boolean isWhitelisted(GHUser user) {
         return trigger.getPermitAll()
-                || whitelisted.contains(user.getLogin())
-                || admins.contains(user.getLogin())
+                || whitelisted().contains(user.getLogin())
+                || admins().contains(user.getLogin())
                 || isInWhitelistedOrganisation(user);
     }
 
     public boolean isAdmin(GHUser user) {
-        return admins.contains(user.getLogin())
+        return admins().contains(user.getLogin())
                 || (trigger.getAllowMembersOfWhitelistedOrgsAsAdmin()
                     && isInWhitelistedOrganisation(user));
     }
@@ -140,7 +161,7 @@ public class Ghprb {
     }
 
     private boolean isInWhitelistedOrganisation(GHUser user) {
-        for (String organisation : organisations) {
+        for (String organisation : organisations()) {
             if (getGitHub().isUserMemberOfOrganization(organisation, user)) {
                 return true;
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -143,6 +143,13 @@ public class GhprbPullRequest {
 
             // the title could have been updated since the original PR was opened
             title = pr.getTitle();
+            
+            // the author of the PR could have been whitelisted since its creation
+            if (!accepted && helper.isWhitelisted(pr.getUser())) {
+                logger.log(Level.INFO, "Pull request #{0}'s author has been whitelisted", new Object[]{id});
+                accepted = true;
+            }
+            
             int commentsChecked = checkComments(pr);
             boolean newCommit = checkCommit(pr.getHead().getSha());
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -284,6 +284,7 @@ public class GhprbPullRequest {
             if (helper.isAdmin(sender)) {
                 logger.log(Level.FINEST, "Admin {0} gave retest phrase", sender);
                 shouldRun = true;
+                triggered = true;
             } else if (accepted && helper.isWhitelisted(sender)) {
                 logger.log(Level.FINEST, "Retest accepted and user {0} is whitelisted", sender);
                 shouldRun = true;


### PR DESCRIPTION
If a project is set to "trigger only", and an admin adds the test/retest phrase in a comment, nothing would happen. The logs would display "Trigger only phrase but we are not triggered". This is because the `triggered` variable was set to true on every other instance of manually triggering a build, **except** when an admin made the comment.

This probably (read: definitely) warrants an additional test, but I don't have a setup java environment nor have I ever previously done testing in java. If you ask and just leave this PR out I'll get to it eventually, otherwise if you want this fix merged sooner (and tested) someone else will have to do that.

EDIT:
I've also found that adding a user to the whitelist doesn't mark existing PR's by that person as accepted (which is expected, since that user can now open any PR and build stuff).

EDIT EDIT:
Now I've found that each PR uses the configuration only as it existed upon its creation (or internal modifications i.e.: `add to whitelist`). Thus, changing the build commands/adding admins etc won't take effect on existing PR's.

Stuff this does:
- [x] allow admins to use the 'trigger only' phrase
[FIXED JENKINS-25572]
- [ ] test allowing admins to use the 'trigger only' phrase
- [x] retroactively accept whitelisted users PR's
[FIXED JENKINS-25574]
- [ ] test retroactively accepting whitelisted users PR's
- [x] use proxies for configuration values instead of storing them locally on PR inception.
[FIXED JENKINS-25603]
- [ ] test configuration changes for existing PR's