### PR TITLE
doc: improve spelling and grammer in useGitHubHooks

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
@@ -1,10 +1,10 @@
 <div>
 	Checking this option will disable regular polling (cron) for changes in GitHub
-	and will try to create GitHub hook. Creating GitHub hook require that user
-	which is specified in <em>GitHub Pull Request Builder</em> configuration have
-	admin rights to specified repository.<br/>
-	If you want to create hook manualy set it for event types:
+	and will try to create a GitHub hook. Creating a GitHub hook requires that the user
+	which is specified in the <em>GitHub Pull Request Builder</em> configuration has
+	admin rights to the specified repository.<br/>
+	If you want to create a hook manually set it for event types:
 		<code>issue_comment</code>,	<code>pull_request</code>
 	and url <code>http://yourserver.com/jenkins/ghprbhook/</code>.<br/>
-	Also your Jenkins server must be accessible from internet.
+	Your Jenkins server must be accessible from internet.
 </div>


### PR DESCRIPTION
This pull request fixes a couple of grammar and spelling issues in the useGitHubHooks help text.
