### PR TITLE
Simplify code. Remove redundant casts and checks.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 
 
 /**
+ * GH PR builder helper class
  * @author janinko
  */
 public class Ghprb {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -9,6 +9,7 @@ import hudson.util.LogTaskListener;
 
 import org.kohsuke.github.GHUser;
 
+import javax.annotation.CheckForNull;
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -30,24 +31,21 @@ public class Ghprb {
     private final Set<String> organisations;
     private final String triggerPhrase;
     private final GhprbTrigger trigger;
-    private final AbstractProject<?, ?> project;
     private final Pattern retestPhrasePattern;
     private final Pattern whitelistPhrasePattern;
     private final Pattern oktotestPhrasePattern;
     private GhprbRepository repository;
     private GhprbBuilds builds;
 
-    public Ghprb(AbstractProject<?, ?> project, GhprbTrigger trigger, ConcurrentMap<Integer, GhprbPullRequest> pulls) {
-        this.project = project;
-
+    public Ghprb(AbstractProject<?, ?> project, GhprbTrigger trigger, @CheckForNull ConcurrentMap<Integer, GhprbPullRequest> pulls) {
         final GithubProjectProperty ghpp = project.getProperty(GithubProjectProperty.class);
         if (ghpp == null || ghpp.getProjectUrl() == null) {
-            throw new IllegalStateException("A GitHub project url is required.");
+            throw new IllegalArgumentException("A GitHub project url is required.");
         }
         String baseUrl = ghpp.getProjectUrl().baseUrl();
         Matcher m = githubUserRepoPattern.matcher(baseUrl);
         if (!m.matches()) {
-            throw new IllegalStateException(String.format("Invalid GitHub project url: %s", baseUrl));
+            throw new IllegalArgumentException(String.format("Invalid GitHub project url: %s", baseUrl));
         }
         final String user = m.group(2);
         final String repo = m.group(3);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuildListener.java
@@ -1,10 +1,11 @@
 package org.jenkinsci.plugins.ghprb;
 
-import com.google.common.base.Optional;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author janinko
@@ -14,21 +15,17 @@ public class GhprbBuildListener extends RunListener<AbstractBuild<?, ?>> {
 
     @Override
     public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
-        final Optional<GhprbTrigger> trigger = findTrigger(build);
-        if (trigger.isPresent()) {
-            trigger.get().getBuilds().onStarted(build, listener.getLogger());
+        GhprbTrigger trigger = build.getProject().getTrigger(GhprbTrigger.class);
+        if (trigger != null) {
+            trigger.getBuilds().onStarted(build, listener.getLogger());
         }
     }
 
     @Override
-    public void onCompleted(AbstractBuild<?, ?> build, TaskListener listener) {
-        final Optional<GhprbTrigger> trigger = findTrigger(build);
-        if (trigger.isPresent()) {
-            trigger.get().getBuilds().onCompleted(build, listener);
+    public void onCompleted(AbstractBuild<?, ?> build, @Nonnull TaskListener listener) {
+        GhprbTrigger trigger = build.getProject().getTrigger(GhprbTrigger.class);
+        if (trigger != null) {
+            trigger.getBuilds().onCompleted(build, listener);
         }
-    }
-
-    private static Optional<GhprbTrigger> findTrigger(AbstractBuild<?, ?> build) {
-        return Optional.fromNullable(build.getProject().getTrigger(GhprbTrigger.class));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuildListener.java
@@ -29,6 +29,6 @@ public class GhprbBuildListener extends RunListener<AbstractBuild<?, ?>> {
     }
 
     private static Optional<GhprbTrigger> findTrigger(AbstractBuild<?, ?> build) {
-        return Optional.fromNullable(GhprbTrigger.extractTrigger(build.getProject()));
+        return Optional.fromNullable(build.getProject().getTrigger(GhprbTrigger.class));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -57,19 +57,21 @@ public class GhprbBuilds {
 
         QueueTaskFuture<?> build = trigger.startJob(cause, repo);
         if (build == null) {
-            logger.log(Level.SEVERE, "Job did not start");
+            logger.log(Level.SEVERE, "Job didn't start");
         }
         return sb.toString();
     }
 
+    /**
+     * Cancel previous builds for specified PR id.
+     * TODO: remove or implement this
+     */
     private boolean cancelBuild(int id) {
         return false;
     }
 
     private GhprbCause getCause(AbstractBuild<?,?> build) {
-        Cause cause = build.getCause(GhprbCause.class);
-        if (cause == null || (!(cause instanceof GhprbCause))) return null;
-        return (GhprbCause) cause;
+        return build.getCause(GhprbCause.class);
     }
 
     public void onStarted(AbstractBuild<?,?> build, PrintStream logger) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
@@ -6,12 +6,14 @@ import org.kohsuke.github.GitUser;
 
 import hudson.model.Cause;
 
+import javax.annotation.Nonnull;
 import java.net.URL;
 
 /**
+ * GitHub PR cause info, immutable.
  * @author Honza Brázdil <jbrazdil@redhat.com>
  */
-public class GhprbCause extends Cause{
+public class GhprbCause extends Cause {
 	private final String commit;
 	private final int pullID;
 	private final boolean merged;
@@ -85,16 +87,14 @@ public class GhprbCause extends Cause{
     }
 
 	/**
-	 * Returns the title of the cause, not null.
-	 * @return
+	 * Returns the title of the cause, never null.
 	 */
-	public String getTitle() {
+	public @Nonnull String getTitle() {
 		return title != null ? title : "";
 	}
 
 	/**
-	 * Returns at most the first 30 characters of the title, or 
-	 * @return
+	 * Returns at most the first 30 characters of the title, or
 	 */
 	public String getAbbreviatedTitle() {
 		return StringUtils.abbreviate(getTitle(), 30);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
@@ -9,6 +9,7 @@ import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 
 /**
+ * Connection helper
  * @author janinko
  */
 public class GhprbGitHub {
@@ -26,7 +27,7 @@ public class GhprbGitHub {
 						.withConnector(new HttpConnectorWithJenkinsProxy())
 						.build();
 			} catch(IOException e) {
-				logger.log(Level.SEVERE, "Can''t connect to {0} using oauth", serverAPIUrl);
+				logger.log(Level.SEVERE, "Can't connect to {0} using oauth", serverAPIUrl);
 				throw e;
 			}
 		} else {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -89,7 +89,7 @@ public class GhprbPullRequestMerge extends Recorder {
 			return true;
 		}
 		
-		trigger = GhprbTrigger.extractTrigger(project);
+		trigger = project.getTrigger(GhprbTrigger.class);
 		if (trigger == null) return false;
 				
 		cause = getCause(build);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -324,7 +324,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public GhprbBuilds getBuilds() {
         if(helper == null) {
-            logger.log(Level.SEVERE, "The ghprb trigger for {0} wasn''t properly started - helper is null", this.project);
+            logger.log(Level.SEVERE, "The ghprb trigger for {0} wasn't properly started - helper is null", this.project);
             return null;
         }
         return helper.getBuilds();
@@ -332,7 +332,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public GhprbRepository getRepository() {
         if(helper == null) {
-            logger.log(Level.SEVERE, "The ghprb trigger for {0} wasn''t properly started - helper is null", this.project);
+            logger.log(Level.SEVERE, "The ghprb trigger for {0} wasn't properly started - helper is null", this.project);
             return null;
         }
         return helper.getRepository();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -95,14 +95,6 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.msgFailure = msgFailure;
     }
 
-    public static GhprbTrigger extractTrigger(AbstractProject<?, ?> p) {
-        Trigger trigger = p.getTrigger(GhprbTrigger.class);
-        if (trigger == null || (!(trigger instanceof GhprbTrigger))) {
-            return null;
-        }
-        return (GhprbTrigger) trigger;
-    }
-
     public static DescriptorImpl getDscp() {
         return DESCRIPTOR;
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -392,7 +392,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
         @Override
         public String getDisplayName() {
-            return "Build GitHub pull request";
+            return "Build GitHub pull requests";
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -397,7 +397,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
         @Override
         public String getDisplayName() {
-            return "GitHub Pull Request Builder";
+            return "Build GitHub pull request";
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -25,6 +25,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 
 import java.io.IOException;
@@ -188,16 +189,14 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     /**
      * Find the previous BuildData for the given pull request number; this may return null
      */
-    private BuildData findPreviousBuildForPullId(StringParameterValue pullIdPv) {
+    private @CheckForNull BuildData findPreviousBuildForPullId(StringParameterValue pullIdPv) {
         // find the previous build for this particular pull request, it may not be the last build
         for (Run<?, ?> r : job.getBuilds()) {
             ParametersAction pa = r.getAction(ParametersAction.class);
             if (pa != null) {
                 for (ParameterValue pv : pa.getParameters()) {
                     if (pv.equals(pullIdPv)) {
-                        for (BuildData bd : r.getActions(BuildData.class)) {
-                            return bd;
-                        }
+                        return r.getAction(BuildData.class);
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -152,9 +152,16 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         
         try {triggerAuthor = getString(cause.getTriggerSender().getName(), "");} catch (Exception e) {}
         try {triggerAuthorEmail = getString(cause.getTriggerSender().getEmail(), "");} catch (Exception e) {}
-        
-        setCommitAuthor(cause, values);
-        
+
+        String authorName = "";
+        String authorEmail = "";
+        if (cause.getCommitAuthor() != null) {
+            authorName = getString(cause.getCommitAuthor().getName(), "");
+            authorEmail = getString(cause.getCommitAuthor().getEmail(), "");
+        }
+
+        values.add(new StringParameterValue("ghprbActualCommitAuthor", authorName));
+        values.add(new StringParameterValue("ghprbActualCommitAuthorEmail", authorEmail));
         values.add(new StringParameterValue("ghprbTriggerAuthor", triggerAuthor));
         values.add(new StringParameterValue("ghprbTriggerAuthorEmail", triggerAuthorEmail));
         final StringParameterValue pullIdPv = new StringParameterValue("ghprbPullId", String.valueOf(cause.getPullID()));
@@ -173,19 +180,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         // one isn't there
         return this.job.scheduleBuild2(job.getQuietPeriod(), cause, new ParametersAction(values), findPreviousBuildForPullId(pullIdPv), new RevisionParameterAction(commitSha));
     }
-    
-    private void setCommitAuthor(GhprbCause cause, ArrayList<ParameterValue> values) {
-    	String authorName = "";
-    	String authorEmail = "";
-    	if (cause.getCommitAuthor() != null) {
-    		authorName = getString(cause.getCommitAuthor().getName(), "");
-    		authorEmail = getString(cause.getCommitAuthor().getEmail(), "");
-    	}
-    	
-        values.add(new StringParameterValue("ghprbActualCommitAuthor", authorName));
-        values.add(new StringParameterValue("ghprbActualCommitAuthorEmail", authorEmail));
-    }
-    
+
     private String getString(String actual, String d) {
     	return actual == null ? d : actual;
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
@@ -44,7 +44,7 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
 	}
 
 	/**
-	 * Calculate the build URL of a build of default type. This will be overriden
+	 * Calculate the build URL of a build of default type. This will be overridden
 	 * by specific build types.
 	 * 
 	 * @return the build URL of a build of default type
@@ -56,7 +56,7 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
 	}
 
 	/**
-	 * Return a downstream iterator of a build of default type. This will be overriden
+	 * Return a downstream iterator of a build of default type. This will be overridden
 	 * by specific build types.
 	 *
 	 * If the receiver of the call has no child projects, it will return an
@@ -77,7 +77,7 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
 	}
 
 	/**
-	 * Return the tests results of a build of default type. This will be overriden
+	 * Return the tests results of a build of default type. This will be overridden
 	 * by specific build types.
 	 *
 	 * @return the tests result of a build of default type


### PR DESCRIPTION
From sources/javadoc:
hudson.model.AbstractProject#getTrigger(Class<T> clazz)
* Gets the specific trigger, or null if the propert is not configured for this job.