### PR TITLE
[JENKINS-25856] Don't trigger PR builds when the project is disabled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -139,6 +139,10 @@ public class Ghprb {
         return user != null && user.getLogin().equals(getGitHub().getBotUserLogin());
     }
 
+    public boolean isProjectDisabled() {
+        return this.project.isDisabled();
+    }
+
     private boolean isInWhitelistedOrganisation(GHUser user) {
         for (String organisation : organisations) {
             if (getGitHub().isUserMemberOfOrganization(organisation, user)) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -197,6 +197,11 @@ public class GhprbPullRequest {
     }
 
     private void tryBuild(GHPullRequest pr) {
+        if(helper.isProjectDisabled()) {
+            logger.log(Level.INFO, "Not triggering a build since the project is disabled");
+            return;
+        }
+
         if (helper.ifOnlyTriggerPhrase() && !triggered) {
             logger.log(Level.FINEST, "Trigger only phrase but we are not triggered");
             shouldRun = false;

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -155,6 +155,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper).ifOnlyTriggerPhrase();
+        verify(helper).isProjectDisabled();
         verify(helper).getWhiteListTargetBranches();
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
@@ -216,6 +217,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper, times(1)).isWhitelisted(eq(ghUser));  // Call to Github API
+        verify(helper, times(2)).isProjectDisabled();
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
@@ -287,8 +289,9 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).listCommits();
         verify(ghPullRequest, times(2)).getBody();
         verifyNoMoreInteractions(ghPullRequest);
-
+;
         verify(helper, times(1)).isWhitelisted(eq(ghUser));  // Call to Github API
+        verify(helper, times(2)).isProjectDisabled();
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
@@ -368,6 +371,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper, times(2)).isWhitelisted(eq(ghUser));  // Call to Github API
+        verify(helper, times(2)).isProjectDisabled();
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();


### PR DESCRIPTION
Currently when the Jenkins project containing the Github Pull Request builder is disabled this plugin will keep on trying to build Pull Requests. This is IMO unexpected behaviour.

This PR fixes that by explicitly checking if the project is enabled before triggering a build. I've added some test cases but granted they're not as good as they could be since it requires a whole lot of stubbing to get the tests going. I wanted to add an integration test but unfortunately it seems that all existing integration tests are broken.

Fixes https://issues.jenkins-ci.org/browse/JENKINS-25856.