### PR TITLE
Option to trigger build on closed pull request, build step to comment on pull request

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -121,6 +121,10 @@ public class Ghprb {
     public boolean ifOnlyTriggerPhrase() {
         return trigger.getOnlyTriggerPhrase();
     }
+    
+    public boolean ifOnlyOnClosed() {
+        return trigger.isOnlyOnClosed();
+    }
 
     public boolean isWhitelisted(GHUser user) {
         return trigger.getPermitAll()

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCommenter.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCommenter.java
@@ -1,0 +1,56 @@
+package org.jenkinsci.plugins.ghprb;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import java.io.IOException;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author Phong Nguyen Le
+ */
+public class GhprbCommenter extends Builder {
+    private final String comment;
+
+    @DataBoundConstructor
+    public GhprbCommenter(String comment) {
+        this.comment = comment;
+    }
+
+    public String getComment() {
+        return comment;
+    }        
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) 
+            throws InterruptedException, IOException {
+        GhprbTrigger trigger = build.getProject().getTrigger(GhprbTrigger.class);
+        if (trigger == null) {
+            throw new AbortException("GitHub Pull Request Builder trigger is not configured for this project");
+        }
+        
+        trigger.getRepository().addComment(Integer.parseInt(build.getBuildVariables().get("ghprbPullId")), 
+                comment, build, listener);
+        return true;
+    }        
+    
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {            
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Comment on GitHub pull request";
+        }
+    
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -150,8 +150,10 @@ public class GhprbPullRequest {
                 logger.log(Level.INFO, "Pull request #{0} was updated on repo {1} but there aren''t any new comments nor commits; that may mean that commit status was updated.", new Object[] {id, reponame});
             }
             updated = pr.getUpdatedAt();
-        }
+        }        
+        logger.log(Level.FINEST, "Checking if the build should be skipped...");
         checkSkipBuild(pr);
+        logger.log(Level.FINEST, "Trying to trigger a build...");
         tryBuild(pr);
     }
 
@@ -234,12 +236,14 @@ public class GhprbPullRequest {
 
             shouldRun = false;
             triggered = false;
+        } else {
+            logger.log(Level.FINEST, "shouldRun is false");
         }
     }
 
-	private void build() {
+    private void build() {
         String message = helper.getBuilds().build(this, triggerSender, commentBody);
-		repo.createCommitStatus(head, GHCommitState.PENDING, null, message,id);
+        repo.createCommitStatus(head, GHCommitState.PENDING, null, message,id);
         logger.log(Level.INFO, message);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -75,32 +75,57 @@ public class GhprbRepository {
             return;
         }
 
-        List<GHPullRequest> openPulls;
-        try {
-            openPulls = ghRepository.getPullRequests(GHIssueState.OPEN);
-        } catch (IOException ex) {
-            logger.log(Level.SEVERE, "Could not retrieve open pull requests.", ex);
-            return;
-        }
-        Set<Integer> closedPulls = new HashSet<Integer>(pulls.keySet());
-
-        for (GHPullRequest pr : openPulls) {
-            if (pr.getHead() == null) {
-                try {
-                    pr = ghRepository.getPullRequest(pr.getNumber());
-                } catch (IOException ex) {
-                    logger.log(Level.SEVERE, "Could not retrieve pr " + pr.getNumber(), ex);
-                    return;
-                }
+        Set<Integer> closedPrIDs;
+        if (helper.ifOnlyOnClosed()) {
+            List<GHPullRequest> closedPulls;
+            try {
+                closedPulls = ghRepository.getPullRequests(GHIssueState.CLOSED);
+            } catch (IOException ex) {
+                logger.log(Level.SEVERE, "Could not retrieve closed pull requests.", ex);
+                return;
             }
-            check(pr);
-            closedPulls.remove(pr.getNumber());
-        }
+            
+            closedPrIDs = new HashSet<Integer>();
+            for (GHPullRequest pr : closedPulls) {
+                if (pr.getHead() == null) {
+                    try {
+                        pr = ghRepository.getPullRequest(pr.getNumber());
+                    } catch (IOException ex) {
+                        logger.log(Level.SEVERE, "Could not retrieve pr " + pr.getNumber(), ex);
+                        return;
+                    }
+                }
+                check(pr);     
+                closedPrIDs.add(pr.getNumber());
+            }
+        } else {
+            List<GHPullRequest> openPulls;
+            try {
+                openPulls = ghRepository.getPullRequests(GHIssueState.OPEN);
+            } catch (IOException ex) {
+                logger.log(Level.SEVERE, "Could not retrieve open pull requests.", ex);
+                return;
+            }
+            closedPrIDs = new HashSet<Integer>(pulls.keySet());
 
-        // remove closed pulls so we don't check them again
-        for (Integer id : closedPulls) {
-            pulls.remove(id);
+            for (GHPullRequest pr : openPulls) {
+                if (pr.getHead() == null) {
+                    try {
+                        pr = ghRepository.getPullRequest(pr.getNumber());
+                    } catch (IOException ex) {
+                        logger.log(Level.SEVERE, "Could not retrieve pr " + pr.getNumber(), ex);
+                        return;
+                    }
+                }
+                check(pr);
+                closedPrIDs.remove(pr.getNumber());
+            }
         }
+        
+        // remove closed pulls so we don't check them again
+        for (Integer id : closedPrIDs) {
+            pulls.remove(id);
+        }        
     }
 
     private void check(GHPullRequest pr) {
@@ -238,28 +263,38 @@ public class GhprbRepository {
     }
 
     void onPullRequestHook(PullRequest pr) {
-        if ("opened".equals(pr.getAction()) || "reopened".equals(pr.getAction())) {
-            GhprbPullRequest pull = pulls.get(pr.getNumber());
-            if (pull == null) {
-                pulls.putIfAbsent(pr.getNumber(), new GhprbPullRequest(pr.getPullRequest(), helper, this));
-                pull = pulls.get(pr.getNumber());
+        if (helper.ifOnlyOnClosed()) {
+            if ("closed".equals(pr.getAction())) {
+                pulls.remove(pr.getNumber());
+                if (helper.ifOnlyOnClosed()) {
+                    logger.log(Level.FINEST, "Check if build should be triggered for the closed pull request #{0}", pr.getNumber());
+                    new GhprbPullRequest(pr.getPullRequest(), helper, this).check(pr.getPullRequest());
+                }        
             }
-            pull.check(pr.getPullRequest());
-        } else if ("synchronize".equals(pr.getAction())) {
-            GhprbPullRequest pull = pulls.get(pr.getNumber());
-            if (pull == null) {
-                pulls.putIfAbsent(pr.getNumber(), new GhprbPullRequest(pr.getPullRequest(), helper, this));
-                pull = pulls.get(pr.getNumber());
-            }
-            if (pull == null) {
-                logger.log(Level.SEVERE, "Pull Request #{0} doesn''t exist", pr.getNumber());
-                return;
-            }
-            pull.check(pr.getPullRequest());
-        } else if ("closed".equals(pr.getAction())) {
-            pulls.remove(pr.getNumber());
         } else {
-            logger.log(Level.WARNING, "Unknown Pull Request hook action: {0}", pr.getAction());
+            if ("opened".equals(pr.getAction()) || "reopened".equals(pr.getAction())) {
+                GhprbPullRequest pull = pulls.get(pr.getNumber());
+                if (pull == null) {
+                    pulls.putIfAbsent(pr.getNumber(), new GhprbPullRequest(pr.getPullRequest(), helper, this));
+                    pull = pulls.get(pr.getNumber());
+                }
+                pull.check(pr.getPullRequest());
+            } else if ("synchronize".equals(pr.getAction())) {
+                GhprbPullRequest pull = pulls.get(pr.getNumber());
+                if (pull == null) {
+                    pulls.putIfAbsent(pr.getNumber(), new GhprbPullRequest(pr.getPullRequest(), helper, this));
+                    pull = pulls.get(pr.getNumber());
+                }
+                if (pull == null) {
+                    logger.log(Level.SEVERE, "Pull Request #{0} doesn''t exist", pr.getNumber());
+                    return;
+                }
+                pull.check(pr.getPullRequest());
+            } else if ("closed".equals(pr.getAction())) {
+                pulls.remove(pr.getNumber());            
+            } else {
+                logger.log(Level.WARNING, "Unknown Pull Request hook action: {0}", pr.getAction());
+            }
         }
         GhprbTrigger.getDscp().save();
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  * @author Honza Brázdil <jbrazdil@redhat.com>
  */
 public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
-    
+
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
     private static final Logger logger = Logger.getLogger(GhprbTrigger.class.getName());
@@ -158,12 +158,12 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         values.add(new StringParameterValue("ghprbActualCommit", cause.getCommit()));
         String triggerAuthor = "";
         String triggerAuthorEmail = "";
-        
+
         try {triggerAuthor = getString(cause.getTriggerSender().getName(), "");} catch (Exception e) {}
         try {triggerAuthorEmail = getString(cause.getTriggerSender().getEmail(), "");} catch (Exception e) {}
-        
+
         setCommitAuthor(cause, values);
-        
+
         values.add(new StringParameterValue("ghprbTriggerAuthor", triggerAuthor));
         values.add(new StringParameterValue("ghprbTriggerAuthorEmail", triggerAuthorEmail));
         final StringParameterValue pullIdPv = new StringParameterValue("ghprbPullId", String.valueOf(cause.getPullID()));
@@ -182,7 +182,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         // one isn't there
         return this.job.scheduleBuild2(job.getQuietPeriod(), cause, new ParametersAction(values), findPreviousBuildForPullId(pullIdPv), new RevisionParameterAction(commitSha));
     }
-    
+
     private void setCommitAuthor(GhprbCause cause, ArrayList<ParameterValue> values) {
     	String authorName = "";
     	String authorEmail = "";
@@ -190,11 +190,11 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     		authorName = getString(cause.getCommitAuthor().getName(), "");
     		authorEmail = getString(cause.getCommitAuthor().getEmail(), "");
     	}
-    	
+
         values.add(new StringParameterValue("ghprbActualCommitAuthor", authorName));
         values.add(new StringParameterValue("ghprbActualCommitAuthorEmail", authorEmail));
     }
-    
+
     private String getString(String actual, String d) {
     	return actual == null ? d : actual;
     }
@@ -240,7 +240,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             logger.log(Level.SEVERE, "Failed to save new whitelist", ex);
         }
     }
-    
+
     public String getAdminlist() {
         if (adminlist == null) {
             return "";
@@ -258,7 +258,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         }
         return whitelist;
     }
-    
+
 
     public String getCommentFilePath() {
     	return commentFilePath;
@@ -292,7 +292,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean isOnlyOnClosed() {
         return onlyOnClosed;
-    }        
+    }
 
     public Boolean getOnlyTriggerPhrase() {
         return onlyTriggerPhrase != null && onlyTriggerPhrase;
@@ -359,12 +359,12 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     public static final class DescriptorImpl extends TriggerDescriptor {
         // GitHub username may only contain alphanumeric characters or dashes and cannot begin with a dash
         private static final Pattern adminlistPattern = Pattern.compile("((\\p{Alnum}[\\p{Alnum}-]*)|\\s)*");
-        
-        
+
+
         /**
-         * These settings only really affect testing.  When Jenkins calls configure() then 
+         * These settings only really affect testing.  When Jenkins calls configure() then
          * the formdata will be used to replace all of these fields.
-         * Leaving them here is useful for testing, but must not be confused with a 
+         * Leaving them here is useful for testing, but must not be confused with a
          * default.  They also should not be used as the default value in the global.jelly
          * file as this value is dynamic and will not be retained once configure() is called.
          */
@@ -383,9 +383,9 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         private List<GhprbBranch> whiteListTargetBranches;
         private Boolean autoCloseFailedPullRequests = false;
         private Boolean displayBuildErrorsOnDownstreamBuilds = false;
-        
-        
-        
+
+
+
         private String username;
         private String password;
         private String accessToken;
@@ -435,8 +435,8 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             displayBuildErrorsOnDownstreamBuilds = formData.getBoolean("displayBuildErrorsOnDownstreamBuilds");
             msgSuccess = formData.getString("msgSuccess");
             msgFailure = formData.getString("msgFailure");
-           
-            
+
+
             save();
             gh = new GhprbGitHub();
             return super.configure(req, formData);
@@ -494,7 +494,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         public String getRetestPhrase() {
             return retestPhrase;
         }
-        
+
         public String getSkipBuildPhrase() {
             return skipBuildPhrase;
         }
@@ -557,7 +557,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             }
             return gh;
         }
-        
+
         public ConcurrentMap<Integer, GhprbPullRequest> getPullRequests(String projectName) {
             ConcurrentMap<Integer, GhprbPullRequest> ret;
             if (jobs.containsKey(projectName)) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -6,7 +6,6 @@ import com.coravy.hudson.plugins.github.GithubProjectProperty;
 import com.google.common.annotations.VisibleForTesting;
 
 import hudson.Extension;
-import hudson.Util;
 import hudson.model.*;
 import hudson.model.StringParameterValue;
 import hudson.model.queue.QueueTaskFuture;
@@ -15,7 +14,6 @@ import hudson.plugins.git.util.BuildData;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
-import hudson.util.LogTaskListener;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.github.GHAuthorization;
@@ -39,7 +37,7 @@ import java.util.regex.Pattern;
  * @author Honza Brázdil <jbrazdil@redhat.com>
  */
 public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
-
+    
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
     private static final Logger logger = Logger.getLogger(GhprbTrigger.class.getName());
@@ -60,6 +58,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     private String msgFailure;
     private transient Ghprb helper;
     private String project;
+    private final boolean onlyOnClosed;
 
     @DataBoundConstructor
     public GhprbTrigger(String adminlist,
@@ -67,6 +66,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         String orgslist,
                         String cron,
                         String triggerPhrase,
+                        boolean onlyOnClosed,
                         Boolean onlyTriggerPhrase,
                         Boolean useGitHubHooks,
                         Boolean permitAll,
@@ -83,6 +83,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.orgslist = orgslist;
         this.cron = cron;
         this.triggerPhrase = triggerPhrase;
+        this.onlyOnClosed = onlyOnClosed;
         this.onlyTriggerPhrase = onlyTriggerPhrase;
         this.useGitHubHooks = useGitHubHooks;
         this.permitAll = permitAll;
@@ -239,7 +240,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             logger.log(Level.SEVERE, "Failed to save new whitelist", ex);
         }
     }
-
+    
     public String getAdminlist() {
         if (adminlist == null) {
             return "";
@@ -288,6 +289,10 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         }
         return triggerPhrase;
     }
+
+    public boolean isOnlyOnClosed() {
+        return onlyOnClosed;
+    }        
 
     public Boolean getOnlyTriggerPhrase() {
         return onlyTriggerPhrase != null && onlyTriggerPhrase;

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbCommenter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbCommenter/config.jelly
@@ -1,0 +1,5 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="Comment" field="comment">
+		<f:textarea clazz="required" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -6,6 +6,9 @@
     <f:checkbox />
   </f:entry>
   <f:advanced>
+    <f:entry title="Trigger build only when a pull request is closed" field="onlyOnClosed">
+        <f:checkbox default="false"/>
+    </f:entry>
     <f:entry title="${%Success message}" field="msgSuccess">
       <f:textarea default="${descriptor.msgSuccess}"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-onlyOnClosed.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-onlyOnClosed.html
@@ -1,0 +1,4 @@
+<div>
+	When checked, only closing a pull request will trigger a build.
+	All other methods of triggering a pull request build are disabled.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -39,7 +39,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, false, null, null, false, null, null
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = GhprbTestUtil.provideConfiguration();
@@ -73,7 +73,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, false, null, null, false, null, null
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -101,7 +101,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, false, null, null, false, null, null
         );
 
         given(commitPointer.getSha()).willReturn("sha");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -92,7 +92,7 @@ public class GhprbPullRequestMergeTest {
 	
 	@Before 
 	public void beforeTest() throws Exception {
-		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, null, null, false, null, null));
+		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, false, null, null, false, null, null));
 
 		ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
 		pulls.put(pullId, pullRequest);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -130,6 +130,7 @@ public class GhprbRepositoryTest {
         mockCommitList();
 
         given(helper.ifOnlyTriggerPhrase()).willReturn(true);
+        given(helper.ifOnlyOnClosed()).willReturn(false);
 
         pulls.put(1, ghprbPullRequest);
 
@@ -156,6 +157,7 @@ public class GhprbRepositoryTest {
 
         verify(helper).ifOnlyTriggerPhrase();
         verify(helper).getWhiteListTargetBranches();
+        verify(helper).ifOnlyOnClosed();
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
@@ -186,6 +188,7 @@ public class GhprbRepositoryTest {
         given(ghUser.getEmail()).willReturn("email");
 
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
+        given(helper.ifOnlyOnClosed()).willReturn(false);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         // WHEN
@@ -219,6 +222,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(1)).ifOnlyOnClosed();        
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
@@ -257,6 +261,7 @@ public class GhprbRepositoryTest {
         given(ghUser.getLogin()).willReturn("login");
 
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
+        given(helper.ifOnlyOnClosed()).willReturn(false);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         // WHEN
@@ -292,6 +297,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).ifOnlyOnClosed();
 
         verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -334,6 +340,7 @@ public class GhprbRepositoryTest {
         given(ghUser.getLogin()).willReturn("login");
 
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
+        given(helper.ifOnlyOnClosed()).willReturn(false);
         given(helper.isRetestPhrase(eq("test this please"))).willReturn(true);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
@@ -371,6 +378,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).ifOnlyOnClosed();
 
         verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("test this please"));
@@ -429,6 +437,8 @@ public class GhprbRepositoryTest {
 
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
         verifyNoMoreInteractions(ghRepository);
+        
+        verify(helper).ifOnlyOnClosed();
         verifyZeroInteractions(helper);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
@@ -64,7 +64,7 @@ public class GhprbDefaultBuildManagerTest extends GhprbITBaseTestCase {
 		MatrixProject project = jenkinsRule.createMatrixProject("MTXPRJ");
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
-			"*/1 * * * *", "retest this please", false, false, false, false,
+			"*/1 * * * *", "retest this please", false, false, false, false, false,
 			false, null, null, false, null, null);
 
 		given(commitPointer.getSha()).willReturn("sha");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
@@ -108,7 +108,7 @@ public class BuildFlowBuildManagerTest extends GhprbITBaseTestCase {
 		buildFlowProject.setDsl(dsl.toString());
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
-			"*/1 * * * *", "retest this please", false, false, false, false,
+			"*/1 * * * *", "retest this please", false, false, false, false, false,
 			false, null, null, false, null, null);
 
 		given(commitPointer.getSha()).willReturn("sha");


### PR DESCRIPTION
I'd like to contribute the following:

- <b>Option to trigger build on closed pull request</b>: when we build a pull request, we have created database and deployed a test instance of our app to validate the fixes and to test the new features. The test instance of the app should be available until the pull request is merged/closed. So we need to be able to trigger a build when a pull request is closed to delete the database and the test instance as well as clean up any other resources used by the pull request.
![screen shot 2014-12-05 at 12 44 52 pm](https://cloud.githubusercontent.com/assets/7797160/5362108/39fb3e38-7f85-11e4-8cfd-310db8ace0ac.png)

- <b>Build step to comment on pull request</b>: until now I have to use curl to post comment using GitHub REST API, it'd be handy to have this build step.