### PR TITLE
Remove duplicate default messages

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -138,12 +138,6 @@ public class GhprbBuilds {
                 }
             }
             
-            if (state == GHCommitState.SUCCESS) {
-                msg.append(GhprbTrigger.getDscp().getMsgSuccess(build));
-            } else {
-                msg.append(GhprbTrigger.getDscp().getMsgFailure(build));
-            }
-
             msg.append("\nRefer to this link for build results (access rights to CI server needed): \n");
             msg.append(generateCustomizedMessage(build));
 


### PR DESCRIPTION
Global build messages are already added starting at https://github.com/ffissore/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java#L163. There is no need to duplicate them
