### PR TITLE
Published URL no longer activates unrelated features like per job messages and PR autoclose

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-publishedURL.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-publishedURL.html
@@ -1,6 +1,4 @@
 <div>
-	<strong>If you don't want to see any comments, leave this field empty.</strong><br/>
-	When filled this plugin will send comment after build is finished.<br/>
 	If your builds are done on private Jenkins instance (eg. behind firewall)
 	and results are published on public Jenkins instance you can fill the public
 	Jenkins url and when a build is finished it will post comment with link to


### PR DESCRIPTION
With current implementation of GhprbBuilds.onCompleted, a missing published url also deactivates unrelated features like per job comments and PR autoclose. See https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java#L123

This PR makes them independent of a published url.