### PR TITLE
Test results comments should be on top

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -1,18 +1,9 @@
 package org.jenkinsci.plugins.ghprb;
 
-import hudson.model.AbstractBuild;
-import hudson.model.Cause;
-import hudson.model.Result;
-import hudson.model.TaskListener;
-import hudson.model.queue.QueueTaskFuture;
-import hudson.plugins.git.util.BuildData;
-
 import org.apache.commons.io.FileUtils;
-
 import org.jenkinsci.plugins.ghprb.manager.GhprbBuildManager;
 import org.jenkinsci.plugins.ghprb.manager.configuration.JobConfiguration;
 import org.jenkinsci.plugins.ghprb.manager.factory.GhprbBuildManagerFactoryUtil;
-
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
@@ -24,6 +15,13 @@ import java.io.PrintStream;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.plugins.git.util.BuildData;
 
 /**
  * @author janinko
@@ -176,7 +174,7 @@ public class GhprbBuilds {
             }
             // Only Append the build's custom message if it has been set.
             if (buildMessage != null && !buildMessage.isEmpty()) {
-                // When the msg is not empty, append a newline first, to seperate it from the rest of the String
+                // When the msg is not empty, append a newline first, to separate it from the rest of the String
                 if (!"".equals(msg.toString())) {
                     msg.append("\n");
                 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -117,6 +117,25 @@ public class GhprbBuilds {
 
         StringBuilder msg = new StringBuilder();
 
+        String buildMessage = null;
+        if (state == GHCommitState.SUCCESS) {
+            if (trigger.getMsgSuccess() != null && !trigger.getMsgSuccess().isEmpty()) {
+                buildMessage = trigger.getMsgSuccess();
+            } else if (GhprbTrigger.getDscp().getMsgSuccess(build) != null && !GhprbTrigger.getDscp().getMsgSuccess(build).isEmpty()) {
+                buildMessage = GhprbTrigger.getDscp().getMsgSuccess(build);
+            }
+        } else if (state == GHCommitState.FAILURE) {
+            if (trigger.getMsgFailure() != null && !trigger.getMsgFailure().isEmpty()) {
+                buildMessage = trigger.getMsgFailure();
+            } else if (GhprbTrigger.getDscp().getMsgFailure(build) != null && !GhprbTrigger.getDscp().getMsgFailure(build).isEmpty()) {
+                buildMessage = GhprbTrigger.getDscp().getMsgFailure(build);
+            }
+        }
+        // Only Append the build's custom message if it has been set.
+        if (buildMessage != null && !buildMessage.isEmpty()) {
+            msg.append(buildMessage).append("\n");
+        }
+        
         String publishedURL = GhprbTrigger.getDscp().getPublishedURL();
         if (publishedURL != null && !publishedURL.isEmpty()) {
             String commentFilePath = trigger.getCommentFilePath();
@@ -157,30 +176,6 @@ public class GhprbBuilds {
                 }
             }
         
-
-            String buildMessage = null;
-            if (state == GHCommitState.SUCCESS) {
-                if (trigger.getMsgSuccess() != null && !trigger.getMsgSuccess().isEmpty()) {
-                    buildMessage = trigger.getMsgSuccess();
-                } else if (GhprbTrigger.getDscp().getMsgSuccess(build) != null && !GhprbTrigger.getDscp().getMsgSuccess(build).isEmpty()) {
-                    buildMessage = GhprbTrigger.getDscp().getMsgSuccess(build);
-                }
-            } else if (state == GHCommitState.FAILURE) {
-                if (trigger.getMsgFailure() != null && !trigger.getMsgFailure().isEmpty()) {
-                    buildMessage = trigger.getMsgFailure();
-                } else if (GhprbTrigger.getDscp().getMsgFailure(build) != null && !GhprbTrigger.getDscp().getMsgFailure(build).isEmpty()) {
-                    buildMessage = GhprbTrigger.getDscp().getMsgFailure(build);
-                }
-            }
-            // Only Append the build's custom message if it has been set.
-            if (buildMessage != null && !buildMessage.isEmpty()) {
-                // When the msg is not empty, append a newline first, to separate it from the rest of the String
-                if (!"".equals(msg.toString())) {
-                    msg.append("\n");
-                }
-                msg.append(buildMessage);
-            }
-
             if (msg.length() > 0) {
                 listener.getLogger().println(msg);
                 repo.addComment(c.getPullID(), msg.toString(), build, listener);


### PR DESCRIPTION
When you display notification from github to chat tool, pull request of the build results comments should be on top.

For example, if you use the IRC hook of github, only first line of comment does not appear in the IRC.