### PR TITLE
small null reference fix in merge trigger after ghprb

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -115,7 +115,7 @@ public class Ghprb {
     }
 
     public boolean isTriggerPhrase(String comment) {
-        return !triggerPhrase.equals("") && comment.contains(triggerPhrase);
+        return !triggerPhrase.equals("") && comment != null && comment.contains(triggerPhrase);
     }
 
     public boolean ifOnlyTriggerPhrase() {


### PR DESCRIPTION
When the trigger phrase is specified in the build config and when the build trigger is set up to trigger on every push, the comment being null causes null reference exception.