### PR TITLE
Make commit status creation into an option, rather than always.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.16-9-SNAPSHOT</version>
+    <version>1.16-9-SNAPSHOT-with-createCommitStatuses</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -127,6 +127,9 @@ public class GhprbRepository {
     }
     
     public void createCommitStatus(AbstractBuild<?, ?> build, String sha1, GHCommitState state, String url, String message, int id, String context, PrintStream stream) {
+        if (!GhprbTrigger.getDscp().getCreateCommitStatuses()) {
+            return;
+        }
         String newMessage = String.format("Setting status of %s to %s with url %s and message: %s", sha1, state, url, message);
         if (stream != null) {
             stream.println(newMessage);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -52,6 +52,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
     private String whitelist;
     private Boolean autoCloseFailedPullRequests;
     private Boolean displayBuildErrorsOnDownstreamBuilds;
+    private Boolean createCommitStatuses;
     private List<GhprbBranch> whiteListTargetBranches;
     private String msgSuccess;
     private String msgFailure;
@@ -70,6 +71,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
                         Boolean permitAll,
                         Boolean autoCloseFailedPullRequests,
                         Boolean displayBuildErrorsOnDownstreamBuilds,
+                        Boolean createCommitStatuses,
                         String commentFilePath,
                         List<GhprbBranch> whiteListTargetBranches,
                         Boolean allowMembersOfWhitelistedOrgsAsAdmin,
@@ -87,6 +89,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         this.permitAll = permitAll;
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.displayBuildErrorsOnDownstreamBuilds = displayBuildErrorsOnDownstreamBuilds;
+        this.createCommitStatuses = createCommitStatuses;
         this.whiteListTargetBranches = whiteListTargetBranches;
         this.commitStatusContext = commitStatusContext;
         this.commentFilePath = commentFilePath;
@@ -318,6 +321,14 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         return displayBuildErrorsOnDownstreamBuilds;
     }
 
+    public Boolean isCreateCommitStatuses() {
+        if (createCommitStatuses == null) {
+            Boolean commitStatuses = getDescriptor().getCreateCommitStatuses();
+            return (commitStatuses != null && commitStatuses);
+        }
+        return createCommitStatuses;
+    }
+
     public List<GhprbBranch> getWhiteListTargetBranches() {
         if (whiteListTargetBranches == null) {
             return new ArrayList<GhprbBranch>();
@@ -384,6 +395,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         private String commitStatusContext = "";
         private Boolean autoCloseFailedPullRequests = false;
         private Boolean displayBuildErrorsOnDownstreamBuilds = false;
+        private Boolean createCommitStatuses = true;
         
         
         
@@ -434,6 +446,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
             unstableAs = formData.getString("unstableAs");
             autoCloseFailedPullRequests = formData.getBoolean("autoCloseFailedPullRequests");
             displayBuildErrorsOnDownstreamBuilds = formData.getBoolean("displayBuildErrorsOnDownstreamBuilds");
+            createCommitStatuses = formData.getBoolean("createCommitStatuses");
             msgSuccess = formData.getString("msgSuccess");
             msgFailure = formData.getString("msgFailure");
             commitStatusContext = formData.getString("commitStatusContext");
@@ -522,6 +535,10 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
         public Boolean getDisplayBuildErrorsOnDownstreamBuilds() {
             return displayBuildErrorsOnDownstreamBuilds;
+        }
+
+        public Boolean getCreateCommitStatuses() {
+            return createCommitStatuses;
         }
 
         public String getServerAPIUrl() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -21,11 +21,14 @@
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>
-    <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
-  	  <f:textarea default="${descriptor.skipBuildPhrase}"/>
-    </f:entry>
+	<f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
+	  <f:textarea default="${descriptor.skipBuildPhrase}"/>
+	</f:entry>
 	<f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
 	  <f:checkbox default="${descriptor.displayBuildErrorsOnDownstreamBuilds}"/>
+	</f:entry>
+	<f:entry title="Enable GitHub commit status creation" field="createCommitStatuses">
+	  <f:checkbox default="${descriptor.createCommitStatuses}"/>
 	</f:entry>
 	<f:entry title="${%Commit Status Context}" field="commitStatusContext">
 		<f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -35,6 +35,9 @@
       <f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
         <f:checkbox />
 	  </f:entry>
+	  <f:entry title="Enable GitHub commit status creation" field="createCommitStatuses">
+	    <f:checkbox default="true"/>
+	  </f:entry>
       <f:entry title="${%Commit Status Context}" field="commitStatusContext">
         <f:textbox />
       </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-createCommitStatuses.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-createCommitStatuses.html
@@ -1,0 +1,3 @@
+<div>
+    Enables creation of GitHub commit statuses based on the result of the triggered build.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -40,7 +40,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, true, null, null, false, null, null, null
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = GhprbTestUtil.provideConfiguration();
@@ -74,7 +74,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, true, null, null, false, null, null, null
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -102,7 +102,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, true, null, null, false, null, null, null
         );
 
         given(commitPointer.getSha()).willReturn("sha");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -92,7 +92,7 @@ public class GhprbPullRequestMergeTest {
 	
 	@Before 
 	public void beforeTest() throws Exception {
-		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, null, null, false, null, null, null));
+		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, true, null, null, false, null, null, null));
 
 		ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
 		pulls.put(pullId, pullRequest);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -102,6 +102,7 @@ public class GhprbTestUtil {
 		jsonObject.put("testMode", "true");
 		jsonObject.put("autoCloseFailedPullRequests", "false");
 		jsonObject.put("displayBuildErrorsOnDownstreamBuilds", "false");
+		jsonObject.put("createCommitStatuses", "true");
 		jsonObject.put("msgSuccess", "Success");
 		jsonObject.put("msgFailure", "Failure");
 		jsonObject.put("commitStatusContext", "Status Context");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
@@ -66,7 +66,7 @@ public class GhprbDefaultBuildManagerTest extends GhprbITBaseTestCase {
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
 			"*/1 * * * *", "retest this please", false, false, false, false,
-			false, null, null, false, null, null, null);
+			false, true, null, null, false, null, null, null);
 
 		given(commitPointer.getSha()).willReturn("sha");
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
@@ -109,7 +109,7 @@ public class BuildFlowBuildManagerTest extends GhprbITBaseTestCase {
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
 			"*/1 * * * *", "retest this please", false, false, false, false,
-			false, null, null, false, null, null, null);
+			false, true, null, null, false, null, null, null);
 
 		given(commitPointer.getSha()).willReturn("sha");
 		JSONObject jsonObject = GhprbTestUtil.provideConfiguration();


### PR DESCRIPTION
This adds per-project and global options to create GitHub commit statuses. We use a lot of pull request triggers for things that don't actually trigger test runs or app code "builds", and so these lead to a lot of pull request status noise if ghprb-plugin creates statuses each time.

No test coverage yet beyond making the existing test suite work. I don't have the time right now to spin up on adding a new test.

Thanks!