### PR TITLE
Updated to latest github-api.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.59</version>
+            <version>1.66</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -59,14 +59,19 @@ public class GhprbPullRequest {
 
     GhprbPullRequest(GHPullRequest pr, Ghprb helper, GhprbRepository repo) {
         id = pr.getNumber();
-        updated = pr.getUpdatedAt();
+        try {
+            updated = pr.getUpdatedAt();
+        } catch (IOException e) {
+            e.printStackTrace();
+            updated = new Date();
+        }
         head = pr.getHead().getSha();
         title = pr.getTitle();
         author = pr.getUser();
         reponame = repo.getName();
         target = pr.getBase().getRef();
         source = pr.getHead().getRef();
-        url = pr.getUrl();
+        url = pr.getHtmlUrl();
         this.pr = pr;
         obtainAuthorEmail(pr);
 
@@ -149,7 +154,12 @@ public class GhprbPullRequest {
             if (!newCommit && commentsChecked == 0) {
                 logger.log(Level.INFO, "Pull request #{0} was updated on repo {1} but there aren''t any new comments nor commits; that may mean that commit status was updated.", new Object[] {id, reponame});
             }
-            updated = pr.getUpdatedAt();
+            try {
+                updated = pr.getUpdatedAt();
+            } catch (IOException e) {
+                e.printStackTrace();
+                updated = new Date();
+            }
         }
         checkSkipBuild(pr);
         tryBuild(pr);
@@ -191,7 +201,13 @@ public class GhprbPullRequest {
     }
 
     private boolean isUpdated(GHPullRequest pr) {
-        boolean ret = updated.compareTo(pr.getUpdatedAt()) < 0;
+        Date lastUpdated = new Date();
+        try {
+            lastUpdated = pr.getUpdatedAt();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        boolean ret = updated.compareTo(lastUpdated) < 0;
         ret = ret || !pr.getHead().getSha().equals(head);
         return ret;
     }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
@@ -8,11 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 
-import antlr.ANTLRException;
-
 import hudson.model.AbstractProject;
-
-import java.io.IOException;
 
 import org.joda.time.DateTime;
 
@@ -47,7 +43,7 @@ public abstract class GhprbITBaseTestCase {
 	// Stubs
 	protected GHRateLimit ghRateLimit = new GHRateLimit();
 
-	protected void beforeTest() throws IOException, ANTLRException {
+	protected void beforeTest() throws Exception {
 		given(ghprbGitHub.get()).willReturn(gitHub);
 		given(gitHub.getRateLimit()).willReturn(ghRateLimit);
 		given(gitHub.getRepository(anyString())).willReturn(ghRepository);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -176,7 +176,7 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getMergeable()).willReturn(true);
         given(ghPullRequest.getTitle()).willReturn("title");
         given(ghPullRequest.getUser()).willReturn(ghUser);
-        given(ghPullRequest.getUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
+        given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
 
         given(ghUser.getEmail()).willReturn("email");
@@ -209,7 +209,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(3)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(3)).getUpdatedAt();
-        verify(ghPullRequest, times(1)).getUrl();
+        verify(ghPullRequest, times(1)).getHtmlUrl();
         verify(ghPullRequest, times(1)).listCommits();
         verify(ghPullRequest, times(2)).getBody();
         verifyNoMoreInteractions(ghPullRequest);
@@ -250,7 +250,7 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getMergeable()).willReturn(true);
         given(ghPullRequest.getTitle()).willReturn("title");
         given(ghPullRequest.getUser()).willReturn(ghUser);
-        given(ghPullRequest.getUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
+        given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
 
         given(ghUser.getEmail()).willReturn("email");
@@ -281,7 +281,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(8)).getHead();
         verify(ghPullRequest, times(3)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
-        verify(ghPullRequest, times(1)).getUrl();
+        verify(ghPullRequest, times(1)).getHtmlUrl();
         verify(ghPullRequest, times(4)).getUpdatedAt();
 
         verify(ghPullRequest, times(1)).getComments();
@@ -329,7 +329,7 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getMergeable()).willReturn(true);
         given(ghPullRequest.getTitle()).willReturn("title");
         given(ghPullRequest.getUser()).willReturn(ghUser);
-        given(ghPullRequest.getUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
+        given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
 
         given(ghUser.getEmail()).willReturn("email");
@@ -364,7 +364,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(3)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(4)).getUpdatedAt();
-        verify(ghPullRequest, times(1)).getUrl();
+        verify(ghPullRequest, times(1)).getHtmlUrl();
 
         verify(ghPullRequest, times(1)).getComments();
         verify(ghPullRequest, times(2)).listCommits();

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -17,7 +17,6 @@ package org.jenkinsci.plugins.ghprb;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.BDDMockito.given;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.joda.time.DateTime;
@@ -29,6 +28,7 @@ import org.mockito.Mockito;
 //import org.mockserver.client.server.MockServerClient;
 //import org.mockserver.model.HttpRequest;
 //import org.mockserver.model.HttpResponse;
+
 
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
@@ -60,7 +60,7 @@ public class GhprbTestUtil {
 	public static void mockPR(
 			GHPullRequest prToMock, GHCommitPointer commitPointer,
 			DateTime... updatedDate)
-		throws MalformedURLException {
+		throws Exception {
 
 		given(prToMock.getHead()).willReturn(commitPointer);
 		given(prToMock.getBase()).willReturn(commitPointer);


### PR DESCRIPTION
The latest API replaces the getUrl method for pull requests with getHtmlUrl.
Fixed #74