### PR TITLE
Allow skip setting the commit status

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -12,39 +12,42 @@
     <f:entry title="${%Failure message}" field="msgFailure">
       <f:textarea default="${descriptor.msgFailure}"/>
     </f:entry>
-	<f:entry title="${%Trigger phrase}" field="triggerPhrase">
-	  <f:textbox />
-	</f:entry>
-	<f:entry title="Only use trigger phrase for build triggering" field="onlyTriggerPhrase">
-	  <f:checkbox />
-	</f:entry>
-	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
-	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
-	</f:entry>
-    <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
-  	  <f:textarea default="${descriptor.skipBuildPhrase}"/>
+    <f:entry title="${%Trigger phrase}" field="triggerPhrase">
+      <f:textbox />
     </f:entry>
-	<f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
-	  <f:checkbox default="${descriptor.displayBuildErrorsOnDownstreamBuilds}"/>
-	</f:entry>
-	<f:entry title="${%Commit Status Context}" field="commitStatusContext">
-		<f:textbox />
-	</f:entry>
-	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-	  <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
-	</f:entry>
-	<f:entry title="${%White list}" field="whitelist">
-	  <f:textarea />
-	</f:entry>
-	<f:entry title="${%Comment file path}" field="commentFilePath">
-	  <f:textbox />
-	</f:entry>
-	<f:entry title="${%List of organisations. Their members will be whitelisted.}" field="orgslist">
-	  <f:textarea />
-	</f:entry>
-	<f:entry title="Allow members of whitelisted organisations as admins" field="allowMembersOfWhitelistedOrgsAsAdmin">
-	  <f:checkbox />
-	</f:entry>
+    <f:entry title="Only use trigger phrase for build triggering" field="onlyTriggerPhrase">
+      <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
+      <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
+    </f:entry>
+    <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
+      <f:textarea default="${descriptor.skipBuildPhrase}"/>
+    </f:entry>
+    <f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
+      <f:checkbox default="${descriptor.displayBuildErrorsOnDownstreamBuilds}"/>
+    </f:entry>
+    <f:entry title="${%Skip setting the commit status?}" field="skipCommitStatus">
+      <f:checkbox default="${descriptor.skipCommitStatus}"/>
+    </f:entry>
+    <f:entry title="${%Commit Status Context}" field="commitStatusContext">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
+      <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
+    </f:entry>
+    <f:entry title="${%White list}" field="whitelist">
+      <f:textarea />
+    </f:entry>
+    <f:entry title="${%Comment file path}" field="commentFilePath">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%List of organisations. Their members will be whitelisted.}" field="orgslist">
+      <f:textarea />
+    </f:entry>
+    <f:entry title="Allow members of whitelisted organisations as admins" field="allowMembersOfWhitelistedOrgsAsAdmin">
+      <f:checkbox />
+    </f:entry>
     <f:entry title="Build every pull request automatically without asking (Dangerous!)." field="permitAll">
       <f:checkbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -34,7 +34,10 @@
       </f:entry>
       <f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
         <f:checkbox />
-	  </f:entry>
+      </f:entry>
+      <f:entry title="${%Skip setting the commit status?}" field="skipCommitStatus">
+        <f:checkbox />
+      </f:entry>
       <f:entry title="${%Commit Status Context}" field="commitStatusContext">
         <f:textbox />
       </f:entry>
@@ -51,7 +54,7 @@
         <f:textbox default=".*test\W+this\W+please.*"/>
       </f:entry>
       <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
-      	<f:textbox default=".*\[skip\W+ci\].*"/>
+        <f:textbox default=".*\[skip\W+ci\].*"/>
       </f:entry>
       <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
         <f:textbox default="H/5 * * * *" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -40,7 +40,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null, false
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = GhprbTestUtil.provideConfiguration();
@@ -74,7 +74,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null, false
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -102,7 +102,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null, false
         );
 
         given(commitPointer.getSha()).willReturn("sha");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -92,7 +92,7 @@ public class GhprbPullRequestMergeTest {
 	
 	@Before 
 	public void beforeTest() throws Exception {
-		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, null, null, false, null, null, null));
+		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, null, null, false, null, null, null, false));
 
 		ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
 		pulls.put(pullId, pullRequest);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -218,7 +218,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
-        verify(helper, times(1)).getTrigger();
+        verify(helper, times(2)).getTrigger();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail();   // Call to Github API
@@ -293,7 +293,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
-        verify(helper, times(1)).getTrigger();
+        verify(helper, times(2)).getTrigger();
 
 //        verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -376,7 +376,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
-        verify(helper, times(2)).getTrigger();
+        verify(helper, times(4)).getTrigger();
 
 //        verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("test this please"));

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -105,6 +105,8 @@ public class GhprbTestUtil {
 		jsonObject.put("msgSuccess", "Success");
 		jsonObject.put("msgFailure", "Failure");
 		jsonObject.put("commitStatusContext", "Status Context");
+		jsonObject.put("skipCommitStatus", "false");
+
 
 		return jsonObject;
 	}

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
@@ -66,7 +66,7 @@ public class GhprbDefaultBuildManagerTest extends GhprbITBaseTestCase {
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
 			"*/1 * * * *", "retest this please", false, false, false, false,
-			false, null, null, false, null, null, null);
+			false, null, null, false, null, null, null, false);
 
 		given(commitPointer.getSha()).willReturn("sha");
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
@@ -109,7 +109,7 @@ public class BuildFlowBuildManagerTest extends GhprbITBaseTestCase {
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
 			"*/1 * * * *", "retest this please", false, false, false, false,
-			false, null, null, false, null, null, null);
+			false, null, null, false, null, null, null, false);
 
 		given(commitPointer.getSha()).willReturn("sha");
 		JSONObject jsonObject = GhprbTestUtil.provideConfiguration();


### PR DESCRIPTION
I've added this setting in because our Jenkins setup involves a testing, a staging and production Jenkins instances. We only want the production instance to set the commit statuses, though, on the other instances we still want to handle the pull requests.

This also seems to be a duplicate of #73.

Please merge which ever is preferred.