### PR TITLE
Fix null pointer exception if the helper method is null.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -151,16 +151,17 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         if (getUseGitHubHooks()) {
             return;
         }
-        
+
+        if (helper == null) {
+            logger.log(Level.SEVERE, "Helper is null, unable to run trigger");
+            return;
+        }
+
         if (helper.isProjectDisabled()) {
             logger.log(Level.FINE, "Project is disabled, ignoring trigger run call");
             return;
         }
         
-        if (helper == null) {
-            logger.log(Level.SEVERE, "Helper is null, unable to run trigger");
-            return;
-        }
         helper.run();
         getDescriptor().save();
     }


### PR DESCRIPTION
Switch around the `null` check to prevent this NPE:

```
2015-05-14 15:05:22.055+1200 [id=64]    WARNING hudson.triggers.Trigger#checkTriggers: org.jenkinsci.plugins.ghprb.GhprbTrigger.run() failed for hudson.model.FreeStyleProject@####[JOBNAME]
java.lang.NullPointerException
        at org.jenkinsci.plugins.ghprb.GhprbTrigger.run(GhprbTrigger.java:155)
......
```

@reviewbybees