### PR TITLE
Commit status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -1,12 +1,13 @@
 package org.jenkinsci.plugins.ghprb;
 
 import hudson.model.AbstractBuild;
-import hudson.model.Cause;
 import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.util.BuildData;
 
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatus;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHIssueState;
@@ -32,84 +33,63 @@ public class GhprbBuilds {
         this.repo = repo;
     }
 
-    public String build(GhprbPullRequest pr, GHUser triggerSender, String commentBody) {
-        StringBuilder sb = new StringBuilder();
-        if (cancelBuild(pr.getId())) {
-            sb.append("Previous build stopped.");
-        }
+    public void build(GhprbPullRequest pr, GHUser triggerSender, String commentBody) {
 
-        sb.append(" Build triggered.");
-
-        if (pr.isMergeable()) {
-            sb.append(" sha1 is merged.");
-        } else {
-            sb.append(" sha1 is original commit.");
-        }
-
-        GhprbCause cause = new GhprbCause(
-                pr.getHead(), 
-                pr.getId(), 
-                pr.isMergeable(), 
-                pr.getTarget(), 
-                pr.getSource(), 
-                pr.getAuthorEmail(), 
-                pr.getTitle(), 
-                pr.getUrl(), 
-                triggerSender, 
-                commentBody,
+        GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getSource(), pr.getAuthorEmail(), pr.getTitle(), pr.getUrl(), triggerSender, commentBody,
                 pr.getCommitAuthor());
 
+        for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommitStatus.class)) {
+            if (ext instanceof GhprbCommitStatus) {
+                try {
+                    ((GhprbCommitStatus) ext).onBuildTriggered(pr, repo.getGitHubRepo());
+                } catch (GhprbCommitStatusException e) {
+                    repo.commentOnFailure(null, null, e);
+                }
+            }
+        }
         QueueTaskFuture<?> build = trigger.startJob(cause, repo);
         if (build == null) {
             logger.log(Level.SEVERE, "Job did not start");
         }
-        return sb.toString();
-    }
-
-    private boolean cancelBuild(int id) {
-        return false;
-    }
-
-    private GhprbCause getCause(AbstractBuild<?, ?> build) {
-        Cause cause = build.getCause(GhprbCause.class);
-        if (cause == null || (!(cause instanceof GhprbCause))) {
-            return null;
-        }
-        return (GhprbCause) cause;
     }
 
     public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
         PrintStream logger = listener.getLogger();
-        GhprbCause c = getCause(build);
+        GhprbCause c = Ghprb.getCause(build);
         if (c == null) {
             return;
         }
-        
+
         GhprbTrigger trigger = Ghprb.extractTrigger(build);
 
         ConcurrentMap<Integer, GhprbPullRequest> pulls = trigger.getDescriptor().getPullRequests(build.getProject().getFullName());
 
         GHPullRequest pr = pulls.get(c.getPullID()).getPullRequest();
-        
+
         try {
             while (pr.getMergeable() == null) {
                 Thread.sleep(1000);
             }
             // TODO: Figure out what to do if the status of the PR has changed.
-//            if (pr.getMergeable() != c.isMerged()) {
-//                listener.fatalError("PR status has changed!");
-//            }
+            // if (pr.getMergeable() != c.isMerged()) {
+            // listener.fatalError("PR status has changed!");
+            // }
         } catch (Exception e) {
             logger.print("Unable to query GitHub for status of PullRequest");
             e.printStackTrace(logger);
         }
 
-        repo.createCommitStatus(build, GHCommitState.PENDING, 
-                (c.isMerged() ? "Build started, sha1 is merged" : "Build started, sha1 is original commit."), c.getPullID(),
-                trigger.getCommitStatusContext(), logger);
+        for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommitStatus.class)) {
+            if (ext instanceof GhprbCommitStatus) {
+                try {
+                    ((GhprbCommitStatus) ext).onBuildStart(build, listener, repo.getGitHubRepo());
+                } catch (GhprbCommitStatusException e) {
+                    repo.commentOnFailure(build, listener, e);
+                }
+            }
+        }
         try {
-            build.setDescription("<a title=\"" + c.getTitle() + "\" href=\"" + c.getUrl() + 
-                    "\">PR #" + c.getPullID() + "</a>: " + c.getAbbreviatedTitle());
+            build.setDescription("<a title=\"" + c.getTitle() + "\" href=\"" + c.getUrl() + "\">PR #" + c.getPullID() + "</a>: " + c.getAbbreviatedTitle());
         } catch (IOException ex) {
             logger.println("Can't update build description");
             ex.printStackTrace(logger);
@@ -117,7 +97,7 @@ public class GhprbBuilds {
     }
 
     public void onCompleted(AbstractBuild<?, ?> build, TaskListener listener) {
-        GhprbCause c = getCause(build);
+        GhprbCause c = Ghprb.getCause(build);
         if (c == null) {
             return;
         }
@@ -136,17 +116,26 @@ public class GhprbBuilds {
             build.getActions().remove(fakeOne);
         }
 
+        for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommitStatus.class)) {
+            if (ext instanceof GhprbCommitStatus) {
+                try {
+                    ((GhprbCommitStatus) ext).onBuildComplete(build, listener, repo.getGitHubRepo());
+                } catch (GhprbCommitStatusException e) {
+                    repo.commentOnFailure(build, listener, e);
+                }
+            }
+        }
+
         GHCommitState state;
         state = Ghprb.getState(build);
-        repo.createCommitStatus(build, state, "Build finished.", c.getPullID(), trigger.getCommitStatusContext(), listener.getLogger());
 
-        buildResultMessage(build, listener, state, c);
+        commentOnBuildResult(build, listener, state, c);
         // close failed pull request automatically
         if (state == GHCommitState.FAILURE && trigger.isAutoCloseFailedPullRequests()) {
             closeFailedRequest(listener, c);
         }
     }
-    
+
     private void closeFailedRequest(TaskListener listener, GhprbCause c) {
         try {
             GHPullRequest pr = repo.getPullRequest(c.getPullID());
@@ -159,16 +148,16 @@ public class GhprbBuilds {
             ex.printStackTrace(listener.getLogger());
         }
     }
-    
-    private void buildResultMessage(AbstractBuild<?, ?> build, TaskListener listener, GHCommitState state, GhprbCause c) {
+
+    private void commentOnBuildResult(AbstractBuild<?, ?> build, TaskListener listener, GHCommitState state, GhprbCause c) {
         StringBuilder msg = new StringBuilder();
-        
-        for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommentAppender.class)){
+
+        for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommentAppender.class)) {
             if (ext instanceof GhprbCommentAppender) {
                 msg.append(((GhprbCommentAppender) ext).postBuildComment(build, listener));
             }
         }
-        
+
         if (msg.length() > 0) {
             listener.getLogger().println(msg);
             repo.addComment(c.getPullID(), msg.toString(), build, listener);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -274,10 +274,7 @@ public class GhprbPullRequest {
     }
 
     private void build() {
-        String message = helper.getBuilds().build(this, triggerSender, commentBody);
-        String context = helper.getTrigger().getCommitStatusContext();
-        repo.createCommitStatus(head, GHCommitState.PENDING, null, message, id, context);
-        logger.log(Level.INFO, message);
+        helper.getBuilds().build(this, triggerSender, commentBody);
     }
 
     // returns false if no new commit

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -7,6 +7,7 @@ import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus;
 import org.kohsuke.github.*;
@@ -124,63 +125,46 @@ public class GhprbRepository {
         }
         pull.check(pr);
     }
-
-    public void createCommitStatus(AbstractBuild<?, ?> build, GHCommitState state, String message, int id, String context, PrintStream stream) {
-        String sha1 = build.getCause(GhprbCause.class).getCommit();
-        createCommitStatus(build, sha1, state, Jenkins.getInstance().getRootUrl() + build.getUrl(), message, id, context, stream);
-    }
-
-    public void createCommitStatus(String sha1, GHCommitState state, String url, String message, int id, String context) {
-        createCommitStatus(null, sha1, state, url, message, id, context, null);
-    }
-
-    public void createCommitStatus(AbstractBuild<?, ?> build, String sha1, GHCommitState state, String url, String message, int id, String context, PrintStream stream) {
-        String newMessage = String.format("Setting status of %s to %s with url %s and message: %s", sha1, state, url, message);
-        if (stream != null) {
-            stream.println(newMessage);
-        } else {
-            logger.log(Level.INFO, newMessage);
+    
+    public void commentOnFailure(AbstractBuild<?, ?> build, TaskListener listener, GhprbCommitStatusException ex) {
+        PrintStream stream = null;
+        if (listener != null) {
+            stream = listener.getLogger();
         }
-        try {
-            if (context != null && !context.isEmpty()) {
-                ghRepository.createCommitStatus(sha1, state, url, message, context);
-            } else {
-                ghRepository.createCommitStatus(sha1, state, url, message);
-            }
-        } catch (IOException ex) {
-            if (ex instanceof FileNotFoundException) {
-              newMessage = "FileNotFoundException means that the credentials Jenkins is using is probably wrong. Or the user account does not have write access to the repo.";
-            } else {
-              newMessage = "Could not update commit status of the Pull Request on GitHub.";
-            }
-            if (stream != null) {
-                stream.println(newMessage);
-                ex.printStackTrace(stream);
-            } else {
-                logger.log(Level.INFO, newMessage, ex);
-            }
-            if (GhprbTrigger.getDscp().getUseComments()) {
+        GHCommitState state = ex.getState();
+        String newMessage;
+        if (ex.getException() instanceof FileNotFoundException) {
+            newMessage = "FileNotFoundException means that the credentials Jenkins is using is probably wrong. Or the user account does not have write access to the repo.";
+          } else {
+            newMessage = "Could not update commit status of the Pull Request on GitHub.";
+          }
+          if (stream != null) {
+              stream.println(newMessage);
+              ex.printStackTrace(stream);
+          } else {
+              logger.log(Level.INFO, newMessage, ex);
+          }
+          if (GhprbTrigger.getDscp().getUseComments()) {
 
-                StringBuilder msg = new StringBuilder(message);
+              StringBuilder msg = new StringBuilder(ex.getMessage());
 
-                if (build != null) {
-                    msg.append("\n");
-                    GhprbTrigger trigger = Ghprb.extractTrigger(build);
-                    for (GhprbExtension ext : Ghprb.matchesAll(trigger.getExtensions(), GhprbBuildStatus.class)) {
-                        if (ext instanceof GhprbCommentAppender) {
-                            msg.append(((GhprbCommentAppender) ext).postBuildComment(build, null));
-                        }
-                    }
-                }
+              if (build != null) {
+                  msg.append("\n");
+                  GhprbTrigger trigger = Ghprb.extractTrigger(build);
+                  for (GhprbExtension ext : Ghprb.matchesAll(trigger.getExtensions(), GhprbBuildStatus.class)) {
+                      if (ext instanceof GhprbCommentAppender) {
+                          msg.append(((GhprbCommentAppender) ext).postBuildComment(build, null));
+                      }
+                  }
+              }
 
-                if (GhprbTrigger.getDscp().getUseDetailedComments() || (state == GHCommitState.SUCCESS || state == GHCommitState.FAILURE)) {
-                    logger.log(Level.INFO, "Trying to send comment.", ex);
-                    addComment(id, msg.toString());
-                }
-            } else {
-                logger.log(Level.SEVERE, "Could not update commit status of the Pull Request on GitHub.");
-            }
-        }
+              if (GhprbTrigger.getDscp().getUseDetailedComments() || (state == GHCommitState.SUCCESS || state == GHCommitState.FAILURE)) {
+                  logger.log(Level.INFO, "Trying to send comment.", ex);
+                  addComment(ex.getId(), msg.toString());
+              }
+          } else {
+              logger.log(Level.SEVERE, "Could not update commit status of the Pull Request on GitHub.");
+          }
     }
 
     public String getName() {
@@ -315,5 +299,9 @@ public class GhprbRepository {
     @VisibleForTesting
     void setHelper(Ghprb helper) {
         this.helper = helper;
+    }
+
+    public GHRepository getGitHubRepo() {
+        return ghRepository;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/GhprbCommitStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/GhprbCommitStatus.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.ghprb.extensions;
+
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+
+import org.jenkinsci.plugins.ghprb.GhprbPullRequest;
+import org.kohsuke.github.GHRepository;
+
+public interface GhprbCommitStatus {
+    
+    public void onBuildTriggered(GhprbPullRequest pr, GHRepository ghRepository) throws GhprbCommitStatusException;
+    public void onBuildStart(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException;
+    public void onBuildComplete(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException;
+
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/GhprbCommitStatusException.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/GhprbCommitStatusException.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.ghprb.extensions;
+
+import java.io.IOException;
+
+import org.kohsuke.github.GHCommitState;
+
+public class GhprbCommitStatusException extends Exception {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 6220095323686649609L;
+    
+    private final IOException exception;
+    private final String message;
+    private final GHCommitState state;
+    private final int id;
+    
+    public GhprbCommitStatusException(IOException exception, GHCommitState state, String message, int id) {
+        this.exception = exception;
+        this.state = state;
+        this.message = message;
+        this.id = id;
+    }
+    
+    public IOException getException() {
+        return exception;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public GHCommitState getState() {
+        return state;
+    }
+    
+    public int getId() {
+        return id;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildLog.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildLog.java
@@ -8,12 +8,10 @@ import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 
 import org.jenkinsci.plugins.ghprb.Ghprb;
-import org.jenkinsci.plugins.ghprb.GhprbTrigger;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbGlobalExtension;
-import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus.DescriptorImpl;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.stapler.DataBoundConstructor;
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildResultMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildResultMessage.java
@@ -10,7 +10,6 @@ import hudson.util.ListBoxModel;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.ghprb.Ghprb;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
-import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus.DescriptorImpl;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildStatus.java
@@ -8,7 +8,6 @@ import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 
 import org.jenkinsci.plugins.ghprb.GhprbTrigger;
-import org.jenkinsci.plugins.ghprb.GhprbTrigger.DescriptorImpl;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
@@ -13,7 +13,6 @@ import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbProjectExtension;
-import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus.DescriptorImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppender, GhprbProjectExtension {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbPublishJenkinsUrl.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbPublishJenkinsUrl.java
@@ -11,7 +11,6 @@ import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbGlobalExtension;
-import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus.DescriptorImpl;
 import org.jenkinsci.plugins.ghprb.manager.GhprbBuildManager;
 import org.jenkinsci.plugins.ghprb.manager.configuration.JobConfiguration;
 import org.jenkinsci.plugins.ghprb.manager.factory.GhprbBuildManagerFactoryUtil;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbNoCommitStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbNoCommitStatus.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.ghprb.extensions.status;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+
+import org.jenkinsci.plugins.ghprb.GhprbPullRequest;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatus;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbProjectExtension;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class GhprbNoCommitStatus extends GhprbExtension implements GhprbCommitStatus, GhprbProjectExtension  {
+    
+
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    @DataBoundConstructor
+    public GhprbNoCommitStatus() {
+        
+    }
+    
+    public void onBuildTriggered(GhprbPullRequest pr, GHRepository ghRepository) throws GhprbCommitStatusException {
+        
+    }
+
+    public void onBuildStart(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException {
+        
+    }
+
+    public void onBuildComplete(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException {
+        
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return DESCRIPTOR;
+    }
+    
+    public static final class DescriptorImpl extends GhprbExtensionDescriptor implements GhprbProjectExtension {
+
+        @Override
+        public String getDisplayName() {
+            return "Do not update commit status";
+        }
+        
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -1,0 +1,119 @@
+package org.jenkinsci.plugins.ghprb.extensions.status;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+
+import java.io.IOException;
+
+import jenkins.model.Jenkins;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.ghprb.Ghprb;
+import org.jenkinsci.plugins.ghprb.GhprbCause;
+import org.jenkinsci.plugins.ghprb.GhprbPullRequest;
+import org.jenkinsci.plugins.ghprb.GhprbTrigger;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatus;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbGlobalExtension;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbProjectExtension;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStatus, GhprbGlobalExtension, GhprbProjectExtension {
+
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+    
+    private final String commitStatusContext;
+    
+    @DataBoundConstructor
+    public GhprbSimpleStatus(String commitStatusContext) {
+        this.commitStatusContext = commitStatusContext == null ? "" : commitStatusContext;
+    }
+    
+    public String getCommitStatusContext() {
+        return commitStatusContext == null ? "" : commitStatusContext;
+    }
+
+    public void onBuildTriggered(GhprbPullRequest pr, GHRepository ghRepository) throws GhprbCommitStatusException {
+        StringBuilder sb = new StringBuilder();
+        GHCommitState state = GHCommitState.PENDING;
+        
+        String context = getCommitStatusContext();
+        if (StringUtils.isEmpty(context)) {
+            context = null;
+        }
+
+        sb.append("Build triggered.");
+
+        if (pr.isMergeable()) {
+            sb.append(" sha1 is merged.");
+        } else {
+            sb.append(" sha1 is original commit.");
+        }
+        String message = sb.toString();
+        try {
+            ghRepository.createCommitStatus(pr.getHead(), state, null, message, context);
+        } catch (IOException e) {
+            throw new GhprbCommitStatusException(e, state, message, pr.getId());
+        }
+    }
+
+    public void onBuildStart(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException {
+        GhprbCause c = Ghprb.getCause(build);
+        String message = (c.isMerged() ? "Build started, sha1 is merged" : "Build started, sha1 is original commit.");
+        createCommitStatus(build, listener, message, repo, GHCommitState.PENDING);
+    }
+
+    public void onBuildComplete(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException {
+        GHCommitState state;
+        state = Ghprb.getState(build);
+        createCommitStatus(build, listener, "Build finished.", repo, state);
+    }
+
+    private void createCommitStatus(AbstractBuild<?, ?> build, TaskListener listener, String message, GHRepository repo, GHCommitState state) throws GhprbCommitStatusException {
+        GhprbCause cause = Ghprb.getCause(build);
+        
+        String sha1 = cause.getCommit();
+        String url = Jenkins.getInstance().getRootUrl() + build.getUrl();
+        
+        listener.getLogger().println(String.format("Setting status of %s to %s with url %s and message: %s", sha1, state, url, message));
+        try {
+            repo.createCommitStatus(sha1, state, url, message, commitStatusContext);
+        } catch (IOException e) {
+            throw new GhprbCommitStatusException(e, state, message, cause.getPullID());
+        }
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return DESCRIPTOR;
+    }
+    
+    public static final class DescriptorImpl extends GhprbExtensionDescriptor implements GhprbGlobalExtension, GhprbProjectExtension {
+        
+        @Override
+        public String getDisplayName() {
+            return "Update commit status during build";
+        }
+        
+        public String getCommitContextDefault(String commitStatusContext){
+            String context = commitStatusContext;
+            if (StringUtils.isEmpty(commitStatusContext)) {
+                for(GhprbExtension extension : GhprbTrigger.getDscp().getExtensions()) {
+                    if (extension instanceof GhprbSimpleStatus) {
+                        context = ((GhprbSimpleStatus) extension).getCommitStatusContext();
+                        break;
+                    }
+                }
+            }
+            return context;
+        }
+    }
+
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -51,8 +51,10 @@
       </f:repeatable>
     </f:entry>
   </f:advanced>
-  <f:entry title="${%Application Setup}">
-    <f:hetero-list oneEach="true" name="extensions" hasHeader="true" 
-    items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"/>
-  </f:entry>
+  <f:advanced title="${%Trigger Setup}">
+    <f:entry title="${%Trigger Setup}">
+      <f:hetero-list oneEach="true" name="extensions" hasHeader="true" 
+        items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"/>
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -21,9 +21,6 @@
 	<f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
 	  <f:checkbox default="${descriptor.displayBuildErrorsOnDownstreamBuilds}"/>
 	</f:entry>
-	<f:entry title="${%Commit Status Context}" field="commitStatusContext">
-		<f:textbox />
-	</f:entry>
 	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
 	  <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
 	</f:entry>
@@ -55,6 +52,7 @@
     </f:entry>
   </f:advanced>
   <f:entry title="${%Application Setup}">
-    <f:hetero-list name="extensions" items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"/>
+    <f:hetero-list name="extensions" hasHeader="true" 
+    items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -52,7 +52,7 @@
     </f:entry>
   </f:advanced>
   <f:entry title="${%Application Setup}">
-    <f:hetero-list name="extensions" hasHeader="true" 
+    <f:hetero-list oneEach="true" name="extensions" hasHeader="true" 
     items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -25,9 +25,6 @@
       <f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
         <f:checkbox />
 	  </f:entry>
-      <f:entry title="${%Commit Status Context}" field="commitStatusContext">
-        <f:textbox />
-      </f:entry>
       <f:entry title="${%Request for testing phrase}" field="requestForTestingPhrase">
         <f:textarea default="Can one of the admins verify this patch?"/>
       </f:entry>
@@ -56,7 +53,8 @@
         method="createApiToken" with="username,password" />
     </f:advanced>
     <f:entry title="${%Application Setup}">
-      <f:hetero-list oneEach="true" name="extensions" items="${descriptor.extensions}" descriptors="${descriptor.getGlobalExtensionDescriptors()}"/>
+      <f:hetero-list oneEach="true" name="extensions" hasHeader="true"
+      items="${descriptor.extensions}" descriptors="${descriptor.getGlobalExtensionDescriptors()}"/>
     </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus/config.jelly
@@ -1,0 +1,5 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+      <f:entry title="${%Commit Status Context}" field="commitStatusContext">
+        <f:textbox default="${descriptor.getCommitContextDefault(instance.commitStatusContext)}" />
+      </f:entry>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -110,8 +110,9 @@ public class GhprbRepositoryTest {
     }
     
     
-    private void addSimpleStatus() {
+    private void addSimpleStatus() throws IOException {
         GhprbSimpleStatus status = new GhprbSimpleStatus("default");
+        trigger.getExtensions().remove(GhprbSimpleStatus.class);
         trigger.getExtensions().add(status);
     }
 
@@ -369,6 +370,8 @@ public class GhprbRepositoryTest {
 
         /** GH PR verifications */
         verify(builds, times(2)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
+        verifyNoMoreInteractions(builds);
+        
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
         verify(ghRepository, times(2)).createCommitStatus(eq("head sha"), eq(PENDING), isNull(String.class), eq(msg), eq("default")); // Call to Github API
         verifyNoMoreInteractions(ghRepository);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.ghprb;
 
+import org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,6 +23,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import hudson.model.AbstractProject;
+import hudson.model.queue.QueueTaskFuture;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -47,6 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doReturn;
 
 /**
  * Unit tests for {@link GhprbRepository}.
@@ -57,6 +60,7 @@ public class GhprbRepositoryTest {
     private static final String TEST_USER_NAME = "test-user";
     private static final String TEST_REPO_NAME = "test-repo";
     private static final Date UPDATE_DATE = new Date();
+    private static final String msg = "Build triggered. sha1 is merged.";
 
     @Mock
     private GitHub gt;
@@ -91,6 +95,7 @@ public class GhprbRepositoryTest {
     public void setUp() throws Exception {
         AbstractProject<?, ?> project = jenkinsRule.createFreeStyleProject("GhprbRepoTest");
         trigger = spy(GhprbTestUtil.getTrigger(null));
+        doReturn(mock(QueueTaskFuture.class)).when(trigger).startJob(any(GhprbCause.class), any(GhprbRepository.class));
         initGHPRWithTestData();
 
         // Mock github API
@@ -101,6 +106,13 @@ public class GhprbRepositoryTest {
         // Mock rate limit
         given(gt.getRateLimit()).willReturn(ghRateLimit);
         increaseRateLimitToDefaults();
+        addSimpleStatus();
+    }
+    
+    
+    private void addSimpleStatus() {
+        GhprbSimpleStatus status = new GhprbSimpleStatus("default");
+        trigger.getExtensions().add(status);
     }
 
     @Test
@@ -197,8 +209,6 @@ public class GhprbRepositoryTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
 
-        given(trigger.getCommitStatusContext()).willReturn("default");
-
         // WHEN
         ghprbRepository.check();
 
@@ -210,7 +220,7 @@ public class GhprbRepositoryTest {
         /** GH PR verifications */
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
-        verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), isNull(String.class), eq("msg"), eq("default")); // Call to Github API
+        verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), isNull(String.class), eq(msg), eq("default")); // Call to Github API
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -229,7 +239,6 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
-        verify(helper, times(1)).getTrigger();
         verify(helper, times(5)).isProjectDisabled();
         verifyNoMoreInteractions(helper);
 
@@ -239,9 +248,8 @@ public class GhprbRepositoryTest {
     }
 
     private GhprbBuilds mockBuilds() throws IOException {
-        GhprbBuilds builds = mock(GhprbBuilds.class);
+        GhprbBuilds builds = spy(new GhprbBuilds(trigger, ghprbRepository));
         given(helper.getBuilds()).willReturn(builds);
-        given(builds.build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class))).willReturn("msg");
         given(ghRepository.createCommitStatus(anyString(), any(GHCommitState.class), anyString(), anyString())).willReturn(null);
         return builds;
     }
@@ -283,7 +291,7 @@ public class GhprbRepositoryTest {
         /** GH PR verifications */
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
-        verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), isNull(String.class), eq("msg")); // Call to Github API
+        verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), isNull(String.class), eq(msg), eq("default")); // Call to Github API
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
@@ -304,7 +312,6 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
-        verify(helper, times(1)).getTrigger();
 
         // verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -352,8 +359,6 @@ public class GhprbRepositoryTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
 
-        given(trigger.getCommitStatusContext()).willReturn("default");
-
         // WHEN
         ghprbRepository.check(); // PR was created
         ghprbRepository.check(); // PR was updated
@@ -365,7 +370,7 @@ public class GhprbRepositoryTest {
         /** GH PR verifications */
         verify(builds, times(2)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
-        verify(ghRepository, times(2)).createCommitStatus(eq("head sha"), eq(PENDING), isNull(String.class), eq("msg"), eq("default")); // Call to Github API
+        verify(ghRepository, times(2)).createCommitStatus(eq("head sha"), eq(PENDING), isNull(String.class), eq(msg), eq("default")); // Call to Github API
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
@@ -387,9 +392,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
-        verify(helper, times(2)).getTrigger();
 
-        // verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("test this please"));
         verify(helper).isOktotestPhrase(eq("test this please"));
         verify(helper).isRetestPhrase(eq("test this please"));

--- a/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
@@ -1,0 +1,77 @@
+package org.jenkinsci.plugins.ghprb.extensions.status;
+
+import org.jenkinsci.plugins.ghprb.GhprbPullRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.github.GHRepository;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GhprbSimpleStatusTest {
+
+    @Mock
+    private GHRepository ghRepository;
+    @Mock
+    private GhprbPullRequest ghprbPullRequest;
+    
+    @Test
+    public void testMergedMessage() throws Exception {
+        String mergedMessage = "Build triggered. sha1 is merged.";
+        given(ghprbPullRequest.getHead()).willReturn("sha");
+        given(ghprbPullRequest.isMergeable()).willReturn(true);
+
+        GhprbSimpleStatus status = spy(new GhprbSimpleStatus("default"));
+        status.onBuildTriggered(ghprbPullRequest, ghRepository);
+        
+        verify(ghRepository).createCommitStatus(eq("sha"), eq(GHCommitState.PENDING), isNull(String.class), eq(mergedMessage), eq("default"));
+        verifyNoMoreInteractions(ghRepository);
+
+        verify(ghprbPullRequest).getHead();
+        verify(ghprbPullRequest).isMergeable();
+        verifyNoMoreInteractions(ghprbPullRequest);
+    }
+    
+    @Test
+    public void testMergeConflictMessage() throws Exception {
+        String mergedMessage = "Build triggered. sha1 is original commit.";
+        given(ghprbPullRequest.getHead()).willReturn("sha");
+        given(ghprbPullRequest.isMergeable()).willReturn(false);
+
+        GhprbSimpleStatus status = spy(new GhprbSimpleStatus("default"));
+        status.onBuildTriggered(ghprbPullRequest, ghRepository);
+        
+        verify(ghRepository).createCommitStatus(eq("sha"), eq(GHCommitState.PENDING), isNull(String.class), eq(mergedMessage), eq("default"));
+        verifyNoMoreInteractions(ghRepository);
+
+        verify(ghprbPullRequest).getHead();
+        verify(ghprbPullRequest).isMergeable();
+        verifyNoMoreInteractions(ghprbPullRequest);
+    }
+    
+    @Test
+    public void testDoesNotSendEmptyContext() throws Exception {
+        String mergedMessage = "Build triggered. sha1 is original commit.";
+        given(ghprbPullRequest.getHead()).willReturn("sha");
+        given(ghprbPullRequest.isMergeable()).willReturn(false);
+
+        GhprbSimpleStatus status = spy(new GhprbSimpleStatus(""));
+        status.onBuildTriggered(ghprbPullRequest, ghRepository);
+        
+        verify(ghRepository).createCommitStatus(eq("sha"), eq(GHCommitState.PENDING), isNull(String.class), eq(mergedMessage), isNull(String.class));
+        verifyNoMoreInteractions(ghRepository);
+
+        verify(ghprbPullRequest).getHead();
+        verify(ghprbPullRequest).isMergeable();
+        verifyNoMoreInteractions(ghprbPullRequest);
+    }
+}


### PR DESCRIPTION
Move the commit status to an extension.  
Default to updating the status, but added an extension that does nothing if that is the desired behavior.  
This is also configured on a per job basis.