### PR TITLE
Fix infinite hang if getMergeable never returns a boolean

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -68,28 +68,35 @@ public class GhprbBuilds {
 
         try {
             int counter = 0;
+            // If the PR is being resolved by GitHub then getMergeable will return null
             Boolean isMergeable = pr.getMergeable();
             Boolean isMerged = pr.isMerged();
+            // Not sure if isMerged can return null, but adding if just in case
+            if (isMerged == null) {
+                isMerged = false;
+            }
             while (isMergeable == null && !isMerged && counter++ < 60) {
                 Thread.sleep(1000);
                 isMergeable = pr.getMergeable();
                 isMerged = pr.isMerged();
-            }
-
-            if (isMergeable != c.isMerged() || isMerged == true) {
-                logger.println("!!! PR status has changed !!!  ");
-                if (isMergeable == null) {
-                    if (isMerged) {
-                        logger.println("PR has already been merged");
-                    } else {
-                        logger.println("PR merge status couldn't be retrieved, GitHub maybe hasn't settled yet");
-                    }
-                } else if (isMergeable) {
-                    logger.println("PR has NO merge conflicts");
-                } else if (!isMergeable) {
-                    logger.println("PR has merge conflicts!");
+                if (isMerged == null) {
+                    isMerged = false;
                 }
             }
+            
+            if (isMerged) {
+                logger.println("PR has already been merged, builds using the merged sha1 will fail!!!");
+            } else if (isMergeable == null) {
+                logger.println("PR merge status couldn't be retrieved, maybe GitHub hasn't settled yet");
+            } else if (isMergeable != c.isMerged()) {
+                logger.println("!!! PR mergeability status has changed !!!  ");
+                 if (isMergeable) {
+                    logger.println("PR now has NO merge conflicts");
+                } else if (!isMergeable) {
+                    logger.println("PR now has merge conflicts!");
+                }
+            }
+            
         } catch (Exception e) {
             logger.print("Unable to query GitHub for status of PullRequest");
             e.printStackTrace(logger);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -67,13 +67,29 @@ public class GhprbBuilds {
         GHPullRequest pr = pulls.get(c.getPullID()).getPullRequest();
 
         try {
-            while (pr.getMergeable() == null) {
+            int counter = 0;
+            Boolean isMergeable = pr.getMergeable();
+            Boolean isMerged = pr.isMerged();
+            while (isMergeable == null && !isMerged && counter++ < 60) {
                 Thread.sleep(1000);
+                isMergeable = pr.getMergeable();
+                isMerged = pr.isMerged();
             }
-            // TODO: Figure out what to do if the status of the PR has changed.
-            // if (pr.getMergeable() != c.isMerged()) {
-            // listener.fatalError("PR status has changed!");
-            // }
+
+            if (isMergeable != c.isMerged() || isMerged == true) {
+                logger.println("!!! PR status has changed !!!  ");
+                if (isMergeable == null) {
+                    if (isMerged) {
+                        logger.println("PR has already been merged");
+                    } else {
+                        logger.println("PR merge status couldn't be retrieved, GitHub maybe hasn't settled yet");
+                    }
+                } else if (isMergeable) {
+                    logger.println("PR has NO merge conflicts");
+                } else if (!isMergeable) {
+                    logger.println("PR has merge conflicts!");
+                }
+            }
         } catch (Exception e) {
             logger.print("Unable to query GitHub for status of PullRequest");
             e.printStackTrace(logger);


### PR DESCRIPTION
It would seem there are two cases where getMergeable() returns null, if GitHub hasn't settled or if the pull request was already merged.  These shouldn't cause the onStart to hang forever.  

Comments are now added if either of the two cases happens, or if one minute just isn't the right time to wait for GitHub to settle.  Fixes #96