### PR TITLE
Added variable for the comment body that triggered the build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -224,6 +224,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         values.add(new StringParameterValue("ghprbTriggerAuthor", triggerAuthor));
         values.add(new StringParameterValue("ghprbTriggerAuthorEmail", triggerAuthorEmail));
+        values.add(new StringParameterValue("ghprbTriggerCommentBody", cause.getCommentBody()));
         final StringParameterValue pullIdPv = new StringParameterValue("ghprbPullId", String.valueOf(cause.getPullID()));
         values.add(pullIdPv);
         values.add(new StringParameterValue("ghprbTargetBranch", String.valueOf(cause.getTargetBranch())));


### PR DESCRIPTION
This pull request adds an environment variable that corresponds to the body of the comment that triggered the build. The environment variable is exposed as `ghprbTriggerCommentBody`.