### PR TITLE
[JENKINS-29322] ServletRequest.getEncoding may be null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -70,7 +70,8 @@ public class GhprbRootAction implements UnprotectedRootAction {
                 return;
             }
             try {
-                payload = URLDecoder.decode(body.substring(8), req.getCharacterEncoding());
+                String encoding = req.getCharacterEncoding();
+                payload = URLDecoder.decode(body.substring(8), encoding != null ? encoding : "UTF-8");
             } catch (UnsupportedEncodingException e) {
                 logger.log(Level.SEVERE, "Error while trying to decode the payload");
                 return;


### PR DESCRIPTION
[JENKINS-29322](https://issues.jenkins-ci.org/browse/JENKINS-29322)

Note that `extractRequestBody` already uses `ServletRequest.getReader` to do some kind of decoding, so I am not sure if it even correct to ask for the request encoding when processing the URL decoding of that already-decoded text. However this is the most conservative change since if this was null, the code would definitely hit the bug, so we cannot be doing any worse.

@reviewbybees