### PR TITLE
Fixing NPE and non-sensical behavior of the GHPRB

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -37,34 +37,38 @@ public class GhprbPullRequestMerge extends Recorder {
 
     private final Boolean onlyAdminsMerge;
     private final Boolean disallowOwnCode;
-    private final Boolean onlyTriggerPhrase;
     private final String mergeComment;
     private final Boolean failOnNonMerge;
     private final Boolean deleteOnMerge;
 
     @DataBoundConstructor
     public GhprbPullRequestMerge(
-            String mergeComment, 
-            boolean onlyTriggerPhrase, 
+            String mergeComment,
             boolean onlyAdminsMerge, 
             boolean disallowOwnCode,
             boolean failOnNonMerge,
             boolean deleteOnMerge) {
 
         this.mergeComment = mergeComment;
-        this.onlyTriggerPhrase = onlyTriggerPhrase;
         this.onlyAdminsMerge = onlyAdminsMerge;
         this.disallowOwnCode = disallowOwnCode;
         this.failOnNonMerge = failOnNonMerge;
         this.deleteOnMerge = deleteOnMerge;
     }
 
-    public String getMergeComment() {
-        return mergeComment;
+    public GhprbPullRequestMerge(
+            String mergeComment,
+            boolean onlyTriggerPhrase,
+            boolean onlyAdminsMerge,
+            boolean disallowOwnCode,
+            boolean failOnNonMerge,
+            boolean deleteOnMerge) {
+
+        this(mergeComment, onlyAdminsMerge, disallowOwnCode, failOnNonMerge, deleteOnMerge);
     }
 
-    public boolean isOnlyTriggerPhrase() {
-        return onlyTriggerPhrase == null ? false : onlyTriggerPhrase;
+    public String getMergeComment() {
+        return mergeComment;
     }
 
     public boolean isOnlyAdminsMerge() {
@@ -137,26 +141,22 @@ public class GhprbPullRequestMerge extends Recorder {
 
         // ignore comments from bot user, this fixes an issue where the bot would auto-merge
         // a PR when the 'request for testing' phrase contains the PR merge trigger phrase and
-        // the bot is a member of a whitelisted organisation
+        // the bot is a member of a whitelisted organization
         if (helper.isBotUser(triggerSender)) {
             logger.println("Comment from bot user " + triggerSender.getLogin() + " ignored.");
             return false;
         }
 
-        boolean intendToMerge = false, commentTrigger = false;
+        boolean intendToMerge = false;
         boolean canMerge = true;
         String commentBody = cause.getCommentBody();
 
-        if (isOnlyTriggerPhrase()) {
-            // If merge can only be triggered by a comment and there is a
-            // comment
-            if (commentBody == null || !helper.isTriggerPhrase(commentBody)) {
-                logger.println("The comment does not contain the required trigger phrase.");
-            } else {
-                intendToMerge = true;
-                commentTrigger = true;
-            }
-        } else {
+        // If merge can only be triggered by a comment and there is a
+        // comment
+        if (commentBody == null || !helper.isTriggerPhrase(commentBody)) {
+            logger.println("The comment does not contain the required trigger phrase.");
+        }
+        else {
             intendToMerge = true;
         }
 
@@ -166,18 +166,19 @@ public class GhprbPullRequestMerge extends Recorder {
             logger.println("Only admins can merge this pull request, "
                     + (triggerSender != null ? triggerSender.getLogin() + " is not an admin"
                             : " and build was triggered via automation") + ".");
-            if (commentTrigger && triggerSender != null) {
-                commentOnRequest(String.format("Code not merged because %s is not in the Admin list.", triggerSender.getName()));
+            if (triggerSender != null) {
+                commentOnRequest(String.format("Code not merged because @%s (%s) is not in the Admin list.",
+                        triggerSender.getLogin(), triggerSender.getName()));
             }
         }
 
         // If there is no intention to merge there is no point checking
         if (intendToMerge && isDisallowOwnCode() && (triggerSender == null || isOwnCode(pr, triggerSender))) {
             canMerge = false;
-            if (commentTrigger && triggerSender != null) {
+            if (triggerSender != null) {
                 logger.println("The commentor is also one of the contributors.");
-                commentOnRequest(String.format("Code not merged because %s has committed code in the request.",
-                        triggerSender.getName()));
+                commentOnRequest(String.format("Code not merged because @%s (%s) has committed code in the request.",
+                        triggerSender.getLogin(), triggerSender.getName()));
             }
         }
 
@@ -199,7 +200,7 @@ public class GhprbPullRequestMerge extends Recorder {
             deleteBranch(build, launcher, listener);
         }
 
-        // We should only fail the build if the trigger phrase is NOT used
+        // We should only fail the build if there is an intent to merge
         if (intendToMerge && !canMerge && isFailOnNonMerge()) {
             listener.finished(Result.FAILURE);
         } else {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/config.jelly
@@ -2,9 +2,6 @@
 	<f:entry title="Merge comment" field="mergeComment">
 		<f:textarea />
 	</f:entry>
-	<f:entry title="Only merge on trigger phrase" field="onlyTriggerPhrase"> 
-		<f:checkbox />
-	</f:entry>	
 	<f:entry title="Only Admin can merge code" field="onlyAdminsMerge">
 		<f:checkbox />
 	</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/global.jelly
@@ -3,9 +3,6 @@
 	  	<f:entry title="Merge comment" field="mergeComment">
 			<f:textarea />
 		</f:entry>
-		<f:entry title="Only merge on trigger phrase" field="onlyTriggerPhrase"> 
-			<f:checkbox />
-		</f:entry>	
 		<f:entry title="Only Admin can merge code" field="onlyAdminsMerge">
 			<f:checkbox />
 		</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/help-onlyTriggerPhrase.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/help-onlyTriggerPhrase.html
@@ -1,4 +1,0 @@
-<div>
-	When checked, only commenting the trigger phrase in the pull request will trigger a build.
-	All other methods of triggering a pull request build are disabled.
-</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -44,6 +44,8 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GhprbPullRequestMergeTest {
@@ -210,6 +212,7 @@ public class GhprbPullRequestMergeTest {
 
         merger.setHelper(helper);
 
+        Mockito.reset(pr);
         return merger;
     }
 
@@ -230,27 +233,35 @@ public class GhprbPullRequestMergeTest {
 
         setupConditions(nonAdminLogin, committerName, committerEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(1)).merge(mergeComment);
 
         setupConditions(adminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(2)).merge(mergeComment);
 
         setupConditions(adminLogin, committerName, committerEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(2)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(3)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, nonCommitterName, nonCommitterEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(3)).merge(mergeComment);
 
         setupConditions(adminLogin, nonCommitterName, nonCommitterEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(3)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, nonCommitterName, nonCommitterEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(3)).merge(mergeComment);
 
         setupConditions(adminLogin, committerName, committerEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(4)).merge(mergeComment);
     }
 
     @Test
@@ -264,9 +275,11 @@ public class GhprbPullRequestMergeTest {
 
         setupConditions(adminLogin, committerName, committerEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(1)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, committerName, committerEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        verify(pr, times(1)).merge(mergeComment);
     }
 
     @Test
@@ -280,9 +293,11 @@ public class GhprbPullRequestMergeTest {
 
         setupConditions(adminLogin, committerName, committerEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(1)).merge(mergeComment);
 
         setupConditions(adminLogin, committerName, committerEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(1)).merge(mergeComment);
     }
 
     @Test
@@ -296,9 +311,11 @@ public class GhprbPullRequestMergeTest {
 
         setupConditions(adminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(1)).merge(mergeComment);
 
         setupConditions(adminLogin, committerName, committerEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        verify(pr, times(1)).merge(mergeComment);
     }
 
     @Test
@@ -312,30 +329,39 @@ public class GhprbPullRequestMergeTest {
 
         setupConditions(nonAdminLogin, nonAdminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        verify(pr, times(0)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, adminLogin, committerName, committerEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        verify(pr, times(0)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, adminLogin, nonCommitterName, nonCommitterEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(0)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, nonAdminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        verify(pr, times(0)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, nonAdminLogin, nonCommitterName, nonCommitterEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(0)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, adminLogin, committerName, committerEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(0)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, nonAdminLogin, committerName, committerEmail, nonTriggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(0)).merge(mergeComment);
         
         setupConditions(adminLogin, adminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        verify(pr, times(0)).merge(mergeComment);
 
         setupConditions(nonAdminLogin, adminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
+        verify(pr, times(1)).merge(mergeComment);
         
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -282,7 +282,7 @@ public class GhprbPullRequestMergeTest {
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);
 
         setupConditions(adminLogin, committerName, committerEmail, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
     }
 
     @Test
@@ -317,19 +317,19 @@ public class GhprbPullRequestMergeTest {
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
 
         setupConditions(nonAdminLogin, adminLogin, nonCommitterName, nonCommitterEmail, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
 
         setupConditions(nonAdminLogin, nonAdminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
 
         setupConditions(nonAdminLogin, nonAdminLogin, nonCommitterName, nonCommitterEmail, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
 
         setupConditions(nonAdminLogin, adminLogin, committerName, committerEmail, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
 
         setupConditions(nonAdminLogin, nonAdminLogin, committerName, committerEmail, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
         
         setupConditions(adminLogin, adminLogin, nonCommitterName, nonCommitterEmail, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);


### PR DESCRIPTION
1. Fix NPEs where `triggerSender` is not available
2. Infer intent to merge based on comment trigger
3. If merge can only triggered by comment and there is no comment, there is no intent to merge, therefore do not fail or check other conditions
4. Do not post comments about commentors not being Admins etc if build is triggered by automation

connected to #158, fixes #158