### PR TITLE
Use the correct SHA1 for Matrix builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
             <version>1.66</version>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -7,6 +7,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import hudson.Extension;
 import hudson.Util;
+import hudson.matrix.MatrixProject;
 import hudson.model.*;
 import hudson.model.AbstractProject;
 import hudson.model.queue.QueueTaskFuture;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -326,17 +326,18 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
      * Find the previous BuildData for the given pull request number; this may return null
      */
     private BuildData findPreviousBuildForPullId(StringParameterValue pullIdPv) {
+        // Don't add the Action if it's a matrix job.
+        // This is suboptimal, but necessary until we find a way to determine if the build we're about to start is
+        // the root build or one of the leaves.
+        if (job instanceof MatrixProject) {
+            return null;
+        }
+
         // find the previous build for this particular pull request, it may not be the last build
         for (Run<?, ?> r : job.getBuilds()) {
             ParametersAction pa = r.getAction(ParametersAction.class);
-            if (pa != null) {
-                for (ParameterValue pv : pa.getParameters()) {
-                    if (pv.equals(pullIdPv)) {
-                        for (BuildData bd : r.getActions(BuildData.class)) {
-                            return bd;
-                        }
-                    }
-                }
+            if (pa != null && pa.getParameters().contains(pullIdPv)) {
+                return r.getAction(BuildData.class);
             }
         }
         return null;


### PR DESCRIPTION
The problem was that job.getBuilds() would return the ongoing matrix
root build, causing to build the previous SHA1 in case a commit was not
the first of the pull request.

The current fix breaks the “smart changes” logic for matrix jobs.
A proper fix that preserves this functionality because it would be very
hard to determine which is a root build of the same run, especially if
the concurrent builds options is enabled.

The PR also simplifies some logic.