### PR TITLE
Don't create a commit status in onEnvironmentSetup()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -122,9 +122,10 @@ public void onBuildTriggered(AbstractProject<?, ?> project, String commitSha, bo
             throw new GhprbCommitStatusException(e, state, message, prId);
         }
     }
-    
+
     public void onEnvironmentSetup(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException {
-        createCommitStatus(build, listener, "Build has started, please wait for results...", repo, GHCommitState.PENDING);
+        // no need to create a commit here -- the onBuildStart() event will fire
+        // soon and will respect's the user's settings for startedStatus.
     }
 
     public void onBuildStart(AbstractBuild<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException {


### PR DESCRIPTION
The commit status that would be created in onEnvironmentSetup() would
happen right after the one from onBuildStart() and thus would wipe
whatever the user wanted to have set there as their startedStatus string
(or e.g.  if the user had specified "--none--" to avoid any update at
all). Remove that status update since it is superfluous.