### PR TITLE
Reduce noise of webhook handling for many jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -10,6 +10,9 @@ import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.io.IOUtils;
+import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GitHub;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -84,15 +87,52 @@ public class GhprbRootAction implements UnprotectedRootAction {
                     new Object[] { type });
             return;
         }
-
-        for (GhprbWebHook webHook : getWebHooks()) {
-            try {
-                webHook.handleWebHook(event, payload, body, signature);
-            } catch (Exception e) {
-                logger.log(Level.SEVERE, "Unable to process web hook for: " + webHook.getProjectName(), e);
-            }
-        }
         
+
+        logger.log(Level.INFO, "Got payload event: {0}", event);
+        
+        try {
+            GitHub gh = GitHub.connectAnonymously();
+            
+            if ("issue_comment".equals(event)) {
+                GHEventPayload.IssueComment issueComment = gh.parseEventPayload(
+                        new StringReader(payload), 
+                        GHEventPayload.IssueComment.class);
+                GHIssueState state = issueComment.getIssue().getState();
+                if (state == GHIssueState.CLOSED) {
+                    logger.log(Level.INFO, "Skip comment on closed PR");
+                    return;
+                }
+                
+
+                for (GhprbWebHook webHook : getWebHooks()) {
+                    try {
+                        webHook.handleComment(issueComment, body, signature);
+                    } catch (Exception e) {
+                        logger.log(Level.SEVERE, "Unable to process web hook for: " + webHook.getProjectName(), e);
+                    }
+                }
+                
+
+            } else if ("pull_request".equals(event)) {
+                GHEventPayload.PullRequest pr = gh.parseEventPayload(
+                        new StringReader(payload), 
+                        GHEventPayload.PullRequest.class);
+
+                for (GhprbWebHook webHook : getWebHooks()) {
+                    try {
+                        webHook.handlePR(pr, body, signature);
+                    } catch (Exception e) {
+                        logger.log(Level.SEVERE, "Unable to process web hook for: " + webHook.getProjectName(), e);
+                    }
+                }
+            } else {
+                logger.log(Level.WARNING, "Request not known");
+            }
+
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        }
     }
 
     private String extractRequestBody(StaplerRequest req) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -89,7 +89,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
         }
         
 
-        logger.log(Level.INFO, "Got payload event: {0}", event);
+        logger.log(Level.FINE, "Got payload event: {0}", event);
         
         try {
             GitHub gh = GitHub.connectAnonymously();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbWebHook.java
@@ -1,7 +1,5 @@
 package org.jenkinsci.plugins.ghprb;
 
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -11,75 +9,50 @@ import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.github.GHEventPayload;
-import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHRepository;
-import org.kohsuke.github.GitHub;
 
 public class GhprbWebHook {
     private static final Logger logger = Logger.getLogger(GhprbWebHook.class.getName());
-    
+
     private final GhprbTrigger trigger;
-    
+
     public GhprbWebHook(GhprbTrigger trigger) {
         this.trigger = trigger;
     }
-    
-    public void handleWebHook(String event, String payload, String body, String signature) {
 
+    public void handleComment(GHEventPayload.IssueComment issueComment, String body, String signature) {
         GhprbRepository repo = trigger.getRepository();
         String repoName = repo.getName();
 
-        logger.log(Level.INFO, "Got payload event: {0}", event);
-        try {
-            GitHub gh = trigger.getGitHub();
-            
-            if ("issue_comment".equals(event)) {
-                GHEventPayload.IssueComment issueComment = gh.parseEventPayload(
-                        new StringReader(payload), 
-                        GHEventPayload.IssueComment.class);
-                GHIssueState state = issueComment.getIssue().getState();
-                if (state == GHIssueState.CLOSED) {
-                    logger.log(Level.INFO, "Skip comment on closed PR");
-                    return;
-                }
-                
-                if (matchRepo(repo, issueComment.getRepository())) {
-                    if (!checkSignature(body, signature, trigger.getGitHubApiAuth().getSecret())){
-                        return;
-                    }
-
-                    logger.log(Level.INFO, "Checking issue comment ''{0}'' for repo {1}", 
-                            new Object[] { issueComment.getComment(), repoName }
-                    );
-                    repo.onIssueCommentHook(issueComment);
-                }
-
-            } else if ("pull_request".equals(event)) {
-                GHEventPayload.PullRequest pr = gh.parseEventPayload(
-                        new StringReader(payload), 
-                        GHEventPayload.PullRequest.class);
-                if (matchRepo(repo, pr.getPullRequest().getRepository())) {
-                    if (!checkSignature(body, signature, trigger.getGitHubApiAuth().getSecret())){
-                        return;
-                    }
-
-                    logger.log(Level.INFO, "Checking PR #{1} for {0}", new Object[] { repoName, pr.getNumber() });
-                    repo.onPullRequestHook(pr);
-                }
-                
-            } else {
-                logger.log(Level.WARNING, "Request not known");
+        if (matchRepo(repo, issueComment.getRepository())) {
+            if (!checkSignature(body, signature, trigger.getGitHubApiAuth().getSecret())) {
+                return;
             }
-        } catch (IOException ex) {
-            logger.log(Level.SEVERE, "Failed to parse github hook payload for " + trigger.getProject(), ex);
+
+            logger.log(Level.INFO, "Checking issue comment ''{0}'' for repo {1}", new Object[] { issueComment.getComment(), repoName });
+            repo.onIssueCommentHook(issueComment);
         }
     }
-    
+
+    public void handlePR(GHEventPayload.PullRequest pr, String body, String signature) {
+        GhprbRepository repo = trigger.getRepository();
+        String repoName = repo.getName();
+
+        if (matchRepo(repo, pr.getPullRequest().getRepository())) {
+            if (!checkSignature(body, signature, trigger.getGitHubApiAuth().getSecret())) {
+                return;
+            }
+
+            logger.log(Level.INFO, "Checking PR #{1} for {0}", new Object[] { repoName, pr.getNumber() });
+            repo.onPullRequestHook(pr);
+        }
+    }
+
     public static boolean checkSignature(String body, String signature, String secret) {
         if (StringUtils.isEmpty(secret)) {
             return true;
         }
-        
+
         if (signature != null && signature.startsWith("sha1=")) {
             String expected = signature.substring(5);
             String algorithm = "HmacSHA1";
@@ -89,28 +62,28 @@ public class GhprbWebHook {
                 mac.init(keySpec);
                 byte[] localSignatureBytes = mac.doFinal(body.getBytes("UTF-8"));
                 String localSignature = Hex.encodeHexString(localSignatureBytes);
-                if (! localSignature.equals(expected)) {
-                    logger.log(Level.SEVERE, "Local signature {0} does not match external signature {1}",
-                            new Object[] {localSignature, expected});
+                if (!localSignature.equals(expected)) {
+                    logger.log(Level.SEVERE, "Local signature {0} does not match external signature {1}", new Object[] { localSignature, expected });
                     return false;
                 }
+
+                logger.log(Level.INFO, "Signatures checking OK");
+                return true;
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "Couldn't match both signatures");
                 return false;
             }
-        } else {
-            logger.log(Level.SEVERE, "Request doesn't contain a signature. Check that github has a secret that should be attached to the hook");
-            return false;
         }
+        
+        logger.log(Level.SEVERE, "Request doesn't contain a signature. Check that github has a secret that should be attached to the hook");
+        return false;
 
-        logger.log(Level.INFO, "Signatures checking OK");
-        return true;
     }
-    
+
     private boolean matchRepo(GhprbRepository ghprbRepo, GHRepository ghRepo) {
         String jobRepoName = ghprbRepo.getName();
         String hookRepoName = ghRepo.getFullName();
-        logger.log(Level.FINE, "Comparing repository names: {0} to {1}, case is ignored", new Object[]{jobRepoName, hookRepoName});
+        logger.log(Level.FINE, "Comparing repository names: {0} to {1}, case is ignored", new Object[] { jobRepoName, hookRepoName });
         return jobRepoName.equalsIgnoreCase(hookRepoName);
     }
 


### PR DESCRIPTION
Webhook logs should only be generated once, and each job doesn't need to handle the processing of the body to an object.  