### PR TITLE
Reduce Trigger Descriptor map size

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -62,7 +62,7 @@ public class Ghprb {
     private GhprbRepository repository;
     private GhprbBuilds builds;
 
-    public Ghprb(AbstractProject<?, ?> project, GhprbTrigger trigger, ConcurrentMap<Integer, GhprbPullRequest> pulls) {
+    public Ghprb(AbstractProject<?, ?> project, GhprbTrigger trigger) {
         this.project = project;
 
         final GithubProjectProperty ghpp = project.getProperty(GithubProjectProperty.class);
@@ -79,7 +79,7 @@ public class Ghprb {
 
         this.trigger = trigger;
 
-        this.repository = new GhprbRepository(user, repo, this, pulls);
+        this.repository = new GhprbRepository(user, repo, this);
         this.builds = new GhprbBuilds(trigger, repository);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -40,8 +40,20 @@ public class GhprbBuilds {
 
     public void build(GhprbPullRequest pr, GHUser triggerSender, String commentBody) {
 
-        GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getSource(), pr.getAuthorEmail(), pr.getTitle(), pr.getUrl(), triggerSender, commentBody,
-                pr.getCommitAuthor(), pr.getPullRequestAuthor(), pr.getDescription(), pr.getAuthorRepoGitUrl());
+        GhprbCause cause = new GhprbCause(pr.getHead(), 
+                pr.getId(), 
+                pr.isMergeable(), 
+                pr.getTarget(), 
+                pr.getSource(), 
+                pr.getAuthorEmail(), 
+                pr.getTitle(), 
+                pr.getUrl(), 
+                triggerSender, 
+                commentBody,
+                pr.getCommitAuthor(), 
+                pr.getPullRequestAuthor(), 
+                pr.getDescription(), 
+                pr.getAuthorRepoGitUrl());
 
         for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommitStatus.class)) {
             if (ext instanceof GhprbCommitStatus) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -68,11 +67,8 @@ public class GhprbBuilds {
 
         GhprbTrigger trigger = Ghprb.extractTrigger(build);
 
-        ConcurrentMap<Integer, GhprbPullRequest> pulls = trigger.getDescriptor().getPullRequests(build.getProject().getFullName());
-
-        GHPullRequest pr = pulls.get(c.getPullID()).getPullRequest();
-
         try {
+            GHPullRequest pr = trigger.getRepository().getPullRequest(c.getPullID());
             int counter = 0;
             // If the PR is being resolved by GitHub then getMergeable will return null
             Boolean isMergeable = pr.getMergeable();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -383,7 +383,7 @@ public class GhprbPullRequest {
         hash = 89 * hash + this.id;
         return hash;
     }
-    
+
     public int getId() {
         return id;
     }
@@ -429,7 +429,7 @@ public class GhprbPullRequest {
     public URL getUrl() {
         return pr.getHtmlUrl();
     }
-    
+
     public GitUser getCommitAuthor() {
         return commitAuthor;
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.ghprb;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.concurrent.ConcurrentMap;
 
 import org.kohsuke.github.GHPullRequestCommitDetail.Commit;
 import org.kohsuke.github.GHPullRequest;
@@ -112,7 +111,7 @@ public class GhprbPullRequestMerge extends Recorder {
         pr = trigger.getRepository().getPullRequest(cause.getPullID());
 
         if (helper == null) {
-            helper = new Ghprb(project, trigger, pulls);
+            helper = new Ghprb(project, trigger);
             helper.init();
         }
 
@@ -256,7 +255,7 @@ public class GhprbPullRequestMerge extends Recorder {
         }
 
         @Override
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType) {
             return true;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -109,15 +109,7 @@ public class GhprbPullRequestMerge extends Recorder {
             return true;
         }
 
-        ConcurrentMap<Integer, GhprbPullRequest> pulls = trigger.getDescriptor().getPullRequests(project.getFullName());
-
-        pr = pulls.get(cause.getPullID()).getPullRequest();
-
-        if (pr == null) {
-            logger.println("Pull request is null for ID: " + cause.getPullID());
-            logger.println("" + pulls.toString());
-            return false;
-        }
+        pr = trigger.getRepository().getPullRequest(cause.getPullID());
 
         if (helper == null) {
             helper = new Ghprb(project, trigger, pulls);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -709,21 +709,21 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         
 
-        public ConcurrentMap<Integer, GhprbPullRequest> getPullRequests(String projectName) {
-            ConcurrentMap<Integer, GhprbPullRequest> ret;
-            if (jobs.containsKey(projectName)) {
-                Map<Integer, GhprbPullRequest> map = jobs.get(projectName);
-                if (!(map instanceof ConcurrentMap)) {
-                    map = new ConcurrentHashMap<Integer, GhprbPullRequest>(map);
-                }
-                jobs.put(projectName, (ConcurrentMap<Integer, GhprbPullRequest>) map);
-                ret = (ConcurrentMap<Integer, GhprbPullRequest>) map;
-            } else {
-                ret = new ConcurrentHashMap<Integer, GhprbPullRequest>();
-                jobs.put(projectName, ret);
-            }
-            return ret;
-        }
+//        public ConcurrentMap<Integer, GhprbPullRequest> getPullRequests(String projectName) {
+//            ConcurrentMap<Integer, GhprbPullRequest> ret;
+//            if (jobs.containsKey(projectName)) {
+//                Map<Integer, GhprbPullRequest> map = jobs.get(projectName);
+//                if (!(map instanceof ConcurrentMap)) {
+//                    map = new ConcurrentHashMap<Integer, GhprbPullRequest>(map);
+//                }
+//                jobs.put(projectName, (ConcurrentMap<Integer, GhprbPullRequest>) map);
+//                ret = (ConcurrentMap<Integer, GhprbPullRequest>) map;
+//            } else {
+//                ret = new ConcurrentHashMap<Integer, GhprbPullRequest>();
+//                jobs.put(projectName, ret);
+//            }
+//            return ret;
+//        }
 
         public List<GhprbBranch> getWhiteListTargetBranches() {
             return whiteListTargetBranches;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -183,7 +183,11 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     }
 
     Ghprb createGhprb(AbstractProject<?, ?> project) {
-        return new Ghprb(project, this, getDescriptor().getPullRequests(project.getFullName()));
+        return new Ghprb(project, this);
+    }
+    
+    public ConcurrentMap<Integer, GhprbPullRequest> getPulls() {
+        return getDescriptor().getPullRequests(_project.getFullName());
     }
 
     @Override
@@ -709,21 +713,21 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         
 
-//        public ConcurrentMap<Integer, GhprbPullRequest> getPullRequests(String projectName) {
-//            ConcurrentMap<Integer, GhprbPullRequest> ret;
-//            if (jobs.containsKey(projectName)) {
-//                Map<Integer, GhprbPullRequest> map = jobs.get(projectName);
-//                if (!(map instanceof ConcurrentMap)) {
-//                    map = new ConcurrentHashMap<Integer, GhprbPullRequest>(map);
-//                }
-//                jobs.put(projectName, (ConcurrentMap<Integer, GhprbPullRequest>) map);
-//                ret = (ConcurrentMap<Integer, GhprbPullRequest>) map;
-//            } else {
-//                ret = new ConcurrentHashMap<Integer, GhprbPullRequest>();
-//                jobs.put(projectName, ret);
-//            }
-//            return ret;
-//        }
+        public ConcurrentMap<Integer, GhprbPullRequest> getPullRequests(String projectName) {
+            ConcurrentMap<Integer, GhprbPullRequest> ret;
+            if (jobs.containsKey(projectName)) {
+                Map<Integer, GhprbPullRequest> map = jobs.get(projectName);
+                if (!(map instanceof ConcurrentMap)) {
+                    map = new ConcurrentHashMap<Integer, GhprbPullRequest>(map);
+                }
+                jobs.put(projectName, (ConcurrentMap<Integer, GhprbPullRequest>) map);
+                ret = (ConcurrentMap<Integer, GhprbPullRequest>) map;
+            } else {
+                ret = new ConcurrentHashMap<Integer, GhprbPullRequest>();
+                jobs.put(projectName, ret);
+            }
+            return ret;
+        }
 
         public List<GhprbBranch> getWhiteListTargetBranches() {
             return whiteListTargetBranches;
@@ -821,5 +825,6 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         
     }
+
 
 }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.ghprb;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kohsuke.github.GHCommitPointer;
@@ -7,6 +8,7 @@ import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
@@ -34,6 +36,16 @@ public class GhprbPullRequestTest {
     private Ghprb helper;
     @Mock
     private GhprbRepository repo;
+    @Mock
+    private GHCommitPointer head;
+    @Mock
+    private GhprbRepository ghprbRepository;
+    
+    @Before
+    public void setup() throws IOException {
+        given(ghprbRepository.getPullRequest(10)).willReturn(pr);
+        given(pr.getHead()).willReturn(head);
+    }
 
     @Test
     public void testConstructorWhenAuthorIsWhitelisted() throws IOException {
@@ -41,6 +53,7 @@ public class GhprbPullRequestTest {
         GHUser ghUser = mock(GHUser.class);
         GHCommitPointer head = mock(GHCommitPointer.class);
         GHCommitPointer base = mock(GHCommitPointer.class);
+        
         given(head.getSha()).willReturn("some sha");
         given(base.getRef()).willReturn("some ref");
 
@@ -96,15 +109,15 @@ public class GhprbPullRequestTest {
         // Mocks for Ghprb
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
-        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
+        GhprbPullRequest ghprbPullRequest = Mockito.spy(new GhprbPullRequest(pr, helper, repo));
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN
         ghprbPullRequest.init(helper, ghprbRepository);
 
         // THEN
-        verify(ghprbRepository, times(1)).getName();
+        verify(ghprbRepository, times(1)).getPullRequest(10);
+        verify(pr, times(2)).getHead();
 
     }
 
@@ -134,7 +147,6 @@ public class GhprbPullRequestTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN
@@ -170,7 +182,6 @@ public class GhprbPullRequestTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN
@@ -210,7 +221,6 @@ public class GhprbPullRequestTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -107,6 +107,7 @@ public class GhprbRepositoryTest {
 
         // Mock github API
         given(helper.getGitHub()).willReturn(gitHub);
+        given(helper.getTrigger()).willReturn(trigger);
         given(gitHub.get()).willReturn(gt);
         given(gt.getRepository(anyString())).willReturn(ghRepository);
 
@@ -178,16 +179,17 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         /** GH PR verifications */
-        verify(ghPullRequest, times(3)).getHead();
-        verify(ghPullRequest, times(1)).getBase();
+        verify(ghPullRequest, times(2)).getHead();
         verify(ghPullRequest, times(2)).getNumber();
         verify(ghPullRequest, times(1)).getUpdatedAt();
+        verify(ghPullRequest, times(1)).getUser();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper).ifOnlyTriggerPhrase();
         verify(helper).getWhiteListTargetBranches();
         verify(helper, times(3)).isProjectDisabled();
         verify(helper).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(2)).getTrigger();
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
@@ -236,10 +238,10 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(7)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(3)).getBase();
+        verify(ghPullRequest, times(5)).getHead();
+        verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(3)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getHtmlUrl();
@@ -253,9 +255,10 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getWhiteListTargetBranches();
         verify(helper, times(5)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(3)).getTrigger();
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(1)).getEmail(); // Call to Github API
+        verify(ghUser, times(2)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
@@ -312,24 +315,25 @@ public class GhprbRepositoryTest {
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
         verifyNoMoreInteractions(ghRepository);
 
-        verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(1)).getTitle();
+        verify(ghPullRequest, times(8)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(3)).getBase();
+        verify(ghPullRequest, times(5)).getHead();
+        verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(1)).getHtmlUrl();
         verify(ghPullRequest, times(3)).getUpdatedAt();
 
         verify(ghPullRequest, times(1)).getComments();
         verify(ghPullRequest, times(1)).listCommits();
-        verify(ghPullRequest, times(2)).getBody();
+        verify(ghPullRequest, times(1)).getBody();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper, times(1)).isWhitelisted(eq(ghUser)); // Call to Github API
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(4)).getTrigger();
 
         // verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -340,7 +344,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(1)).getEmail(); // Call to Github API
+        verify(ghUser, times(2)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
@@ -398,13 +402,13 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(10)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(3)).getBase();
+        verify(ghPullRequest, times(5)).getHead();
+        verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(3)).getUpdatedAt();
-        verify(ghPullRequest, times(1)).getHtmlUrl();
+        verify(ghPullRequest, times(2)).getHtmlUrl();
 
         verify(ghPullRequest, times(1)).getComments();
         verify(ghPullRequest, times(2)).listCommits();
@@ -423,9 +427,10 @@ public class GhprbRepositoryTest {
         verify(helper).isAdmin(eq(ghUser));
         verify(helper, times(6)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(4)).getTrigger();
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(1)).getEmail(); // Call to Github API
+        verify(ghUser, times(3)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
 
@@ -475,8 +480,8 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(gt);
 
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
-        verifyNoMoreInteractions(ghRepository);
-        verifyZeroInteractions(helper);
+        verify(helper, times(1)).getTrigger();
+        verifyNoMoreInteractions(helper, ghRepository);
     }
 
     @Test
@@ -534,8 +539,10 @@ public class GhprbRepositoryTest {
         given(head.getSha()).willReturn("head sha");
 
         pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>();
-        ghprbRepository = new GhprbRepository(TEST_USER_NAME, TEST_REPO_NAME, helper, pulls);
+        ghprbRepository = new GhprbRepository(TEST_USER_NAME, TEST_REPO_NAME, helper);
         ghprbPullRequest = new GhprbPullRequest(ghPullRequest, helper, ghprbRepository);
+        
+        given(trigger.getPulls()).willReturn(pulls);
 
         // Reset mocks not to mix init data invocations with tests
         reset(ghPullRequest, ghUser, helper, head, base);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -21,6 +21,8 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.joda.time.DateTime;
 import org.kohsuke.github.GHCommitPointer;
@@ -38,6 +40,7 @@ import hudson.plugins.git.UserRemoteConfig;
 import net.sf.json.JSONObject;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class GhprbTestUtil {
 
@@ -371,6 +374,10 @@ public class GhprbTestUtil {
         }
         
         GhprbTrigger trigger = spy(req.bindJSON(GhprbTrigger.class, defaults));
+        
+
+        ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
+        Mockito.doReturn(pulls).when(trigger).getPulls();
         
         return trigger;
     }


### PR DESCRIPTION
Many of the variables used in GhprbPullRequest can be grabbed as desired instead of stored as a permanent part of the object.  Some of them can also be fetched on init from the repo and some only matter for a single check.  