### PR TITLE
Fix issues with authentication for hooks.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -448,13 +448,8 @@ public class Ghprb {
         
         List<StandardCredentials> credentials;
         
-        if (context == null) {
-            credentials = CredentialsProvider.lookupCredentials(StandardCredentials.class, Jenkins.getInstance(), ACL.SYSTEM,
-                    URIRequirementBuilder.fromUri(uri).build());
-        } else {
-            credentials = CredentialsProvider.lookupCredentials(StandardCredentials.class, context, ACL.SYSTEM,
-                    URIRequirementBuilder.fromUri(uri).build());
-        }
+        credentials = CredentialsProvider.lookupCredentials(StandardCredentials.class, (Item) null, ACL.SYSTEM,
+                URIRequirementBuilder.fromUri(uri).build());
         
         logger.log(Level.FINE, "Found {0} credentials", new Object[]{credentials.size()});
         

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -42,7 +42,6 @@ import org.kohsuke.github.GHUser;
 
 import java.net.URI;
 import java.util.*;
-import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -62,7 +61,7 @@ public class Ghprb {
     private GhprbRepository repository;
     private GhprbBuilds builds;
 
-    public Ghprb(AbstractProject<?, ?> project, GhprbTrigger trigger, ConcurrentMap<Integer, GhprbPullRequest> pulls) {
+    public Ghprb(AbstractProject<?, ?> project, GhprbTrigger trigger) {
         this.project = project;
 
         final GithubProjectProperty ghpp = project.getProperty(GithubProjectProperty.class);
@@ -79,7 +78,7 @@ public class Ghprb {
 
         this.trigger = trigger;
 
-        this.repository = new GhprbRepository(user, repo, this, pulls);
+        this.repository = new GhprbRepository(user, repo, this);
         this.builds = new GhprbBuilds(trigger, repository);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,8 +40,20 @@ public class GhprbBuilds {
 
     public void build(GhprbPullRequest pr, GHUser triggerSender, String commentBody) {
 
-        GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getSource(), pr.getAuthorEmail(), pr.getTitle(), pr.getUrl(), triggerSender, commentBody,
-                pr.getCommitAuthor(), pr.getPullRequestAuthor(), pr.getDescription(), pr.getAuthorRepoGitUrl());
+        GhprbCause cause = new GhprbCause(pr.getHead(), 
+                pr.getId(), 
+                pr.isMergeable(), 
+                pr.getTarget(), 
+                pr.getSource(), 
+                pr.getAuthorEmail(), 
+                pr.getTitle(), 
+                pr.getUrl(), 
+                triggerSender, 
+                commentBody,
+                pr.getCommitAuthor(), 
+                pr.getPullRequestAuthor(), 
+                pr.getDescription(), 
+                pr.getAuthorRepoGitUrl());
 
         for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommitStatus.class)) {
             if (ext instanceof GhprbCommitStatus) {
@@ -68,11 +79,8 @@ public class GhprbBuilds {
 
         GhprbTrigger trigger = Ghprb.extractTrigger(build);
 
-        ConcurrentMap<Integer, GhprbPullRequest> pulls = trigger.getDescriptor().getPullRequests(build.getProject().getFullName());
-
-        GHPullRequest pr = pulls.get(c.getPullID()).getPullRequest();
-
         try {
+            GHPullRequest pr = trigger.getRepository().getPullRequest(c.getPullID());
             int counter = 0;
             // If the PR is being resolved by GitHub then getMergeable will return null
             Boolean isMergeable = pr.getMergeable();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -8,7 +8,6 @@ import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
-import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitUser;
 
@@ -27,31 +26,35 @@ import java.util.logging.Logger;
 public class GhprbPullRequest {
 
     private static final Logger logger = Logger.getLogger(GhprbPullRequest.class.getName());
+    
+    @Deprecated @SuppressWarnings("unused") private transient GHUser author;
+    @Deprecated @SuppressWarnings("unused") private transient String title;
+    @Deprecated @SuppressWarnings("unused") private transient String reponame;
+    @Deprecated @SuppressWarnings("unused") private transient String authorEmail;
+    @Deprecated @SuppressWarnings("unused") private transient URL url;
+    @Deprecated @SuppressWarnings("unused") private transient String description;
 
     private final int id;
-    private final GHUser author;
-    private final GHPullRequest pr;
-    private String title;
-    private Date updated;
-    private String head;
-    private String authorRepoGitUrl;
-    private boolean mergeable;
-    private String reponame;
+   
+    private Date updated; // Needed to track when the PR was updated
     private String target;
     private String source;
-    private String authorEmail;
-    private URL url;
-    private String description;
+    private String head;
+    
+    private boolean accepted = false; // Needed to see if the PR has been added to the accepted list
 
-    private GHUser triggerSender;
-    private GitUser commitAuthor;
 
-    private boolean shouldRun = false;
-    private boolean accepted = false;
-    private boolean triggered = false;
+    private transient String authorRepoGitUrl; // Can be refreshed as needed.
+    private transient Ghprb helper; // will be refreshed each time GhprbRepository.init() is called
+    private transient GhprbRepository repo; // will be refreshed each time GhprbRepository.init() is called
+    private transient GHPullRequest pr; // will be refreshed each time GhprbRepository.init() is called
 
-    private transient Ghprb helper;
-    private transient GhprbRepository repo;
+    private transient GHUser triggerSender; // Only needed for a single build
+    private transient GitUser commitAuthor; // Only needed for a single build
+    
+    private transient boolean shouldRun = false; // Declares if we should run the build this time.
+    private transient boolean triggered = false; // Only lets us know if the trigger phrase was used for this run
+    private transient boolean mergeable = false; // Only works as an easy way to pass the value around for the start of this build
 
     private String commentBody;
 
@@ -63,26 +66,25 @@ public class GhprbPullRequest {
             e.printStackTrace();
             updated = new Date();
         }
-        GHCommitPointer commitPointer = pr.getHead();
-		head = commitPointer.getSha();
-        title = pr.getTitle();
-        author = pr.getUser();
-        GHRepository repository = commitPointer.getRepository();
-        if (repository != null) {
-            authorRepoGitUrl = repository.gitHttpTransportUrl();
-        }
-        reponame = repo.getName();
+        GHCommitPointer prHead = pr.getHead();
+        head = prHead.getSha();
+        source = prHead.getRef();
         target = pr.getBase().getRef();
-        source = commitPointer.getRef();
-        url = pr.getHtmlUrl();
+        
         this.pr = pr;
-        obtainAuthorEmail(pr);
 
         this.helper = helper;
         this.repo = repo;
-        this.description = pr.getBody();
+        
+        GHUser author = pr.getUser();
+        String reponame = repo.getName();
+        
 
-        if (helper.isWhitelisted(author)) {
+        if (prHead != null && prHead.getRepository() != null) {
+            authorRepoGitUrl = prHead.getRepository().gitHttpTransportUrl();
+        }
+
+        if (helper.isWhitelisted(getPullRequestAuthor())) {
             accepted = true;
             shouldRun = true;
         } else {
@@ -91,15 +93,19 @@ public class GhprbPullRequest {
         }
 
         logger.log(Level.INFO, "Created Pull Request #{0} on {1} by {2} ({3}) updated at: {4} SHA: {5}", 
-                new Object[] { id, reponame, author.getLogin(), authorEmail, updated, head }
+                new Object[] { id, reponame, author.getLogin(), getAuthorEmail(), updated, prHead.getRef() }
         );
     }
 
-    public void init(Ghprb helper, GhprbRepository repo) {
+    public void init(Ghprb helper, GhprbRepository repo) throws IOException {
         this.helper = helper;
         this.repo = repo;
-        if (reponame == null) {
-            reponame = repo.getName(); // If this instance was created before v1.8, it can be null.
+        pr = repo.getPullRequest(id);
+        
+        GHCommitPointer prHead = pr.getHead();
+
+        if (prHead != null && prHead.getRepository() != null) {
+            authorRepoGitUrl = prHead.getRepository().gitHttpTransportUrl();
         }
     }
 
@@ -113,14 +119,8 @@ public class GhprbPullRequest {
             logger.log(Level.FINE, "Project is disabled, ignoring pull request");
             return;
         }
-        if (target == null) {
-            target = pr.getBase().getRef(); // If this instance was created before target was introduced (before v1.8), it can be null.
-        }
-        if (source == null) {
-            source = pr.getHead().getRef(); // If this instance was created before target was introduced (before v1.8), it can be null.
-        }
 
-        updatePR(pr, author);
+        updatePR(pr, pr.getUser());
 
         checkSkipBuild(pr);
         tryBuild(pr);
@@ -158,10 +158,11 @@ public class GhprbPullRequest {
         tryBuild(pr);
     }
     
-    private void updatePR(GHPullRequest pr, GHUser author) {
+    private void updatePR(GHPullRequest pr, GHUser user) {
+        
         Date lastUpdateTime = updated;
         if (pr != null && isUpdated(pr)) {
-            logger.log(Level.INFO, "Pull request #{0} was updated on {1} at {2} by {3}", new Object[] { id, reponame, updated, author });
+            logger.log(Level.INFO, "Pull request #{0} was updated on {1} at {2} by {3}", new Object[] { id, repo.getName(), updated, user });
 
             // the author of the PR could have been whitelisted since its creation
             if (!accepted && helper.isWhitelisted(pr.getUser())) {
@@ -169,16 +170,13 @@ public class GhprbPullRequest {
                 accepted = true;
             }
             
-            // the title or description could have been updated since the original PR was opened
-            title = pr.getTitle();
-            description = pr.getBody();
             int commentsChecked = checkComments(pr, lastUpdateTime);
-            boolean newCommit = checkCommit(pr.getHead().getSha());
+            boolean newCommit = checkCommit(pr.getHead());
 
             if (!newCommit && commentsChecked == 0) {
                 logger.log(Level.INFO, "Pull request #{0} was updated on repo {1} but there aren''t any new comments nor commits; "
                         + "that may mean that commit status was updated.", 
-                        new Object[] { id, reponame }
+                        new Object[] { id, repo.getName() }
                 );
             }
         }
@@ -190,6 +188,8 @@ public class GhprbPullRequest {
             // no branches in white list means we should test all
             return true;
         }
+        
+        String target = getTarget();
         for (GhprbBranch b : branches) {
             if (b.matches(target)) {
                 // the target branch is in the whitelist!
@@ -235,12 +235,6 @@ public class GhprbPullRequest {
         if (shouldRun) {
             logger.log(Level.FINEST, "Running the build");
 
-            if (authorEmail == null) {
-                // If this instance was create before authorEmail was introduced (before v1.10), it can be null.
-                obtainAuthorEmail(pr);
-                logger.log(Level.FINEST, "Author email was not set, trying to set it to {0}", authorEmail);
-            }
-
             if (pr != null) {
                 logger.log(Level.FINEST, "PR is not null, checking if mergable");
                 checkMergeable(pr);
@@ -270,12 +264,12 @@ public class GhprbPullRequest {
     }
 
     // returns false if no new commit
-    private boolean checkCommit(String sha) {
-        if (head.equals(sha)) {
+    private boolean checkCommit(GHCommitPointer sha) {
+        if (head.equals(sha.getSha())) {
             return false;
         }
-        logger.log(Level.FINE, "New commit. Sha: {0} => {1}", new Object[] { head, sha });
-        head = sha;
+        logger.log(Level.FINE, "New commit. Sha: {0} => {1}", new Object[] { head, sha.getSha() });
+        head = sha.getSha();
         if (accepted) {
             shouldRun = true;
         }
@@ -285,6 +279,7 @@ public class GhprbPullRequest {
     private void checkComment(GHIssueComment comment) throws IOException {
         GHUser sender = comment.getUser();
         String body = comment.getBody();
+        GHUser author = pr.getUser();
 
         // Disabled until more advanced configs get set up
         // ignore comments from bot user, this fixes an issue where the bot would auto-whitelist
@@ -353,7 +348,7 @@ public class GhprbPullRequest {
         return count;
     }
 
-    private void checkMergeable(GHPullRequest pr) {
+    public boolean checkMergeable(GHPullRequest pr) {
         try {
             int r = 5;
             Boolean isMergeable = pr.getMergeable();
@@ -368,17 +363,9 @@ public class GhprbPullRequest {
             }
             mergeable = isMergeable != null && isMergeable;
         } catch (IOException e) {
-            mergeable = false;
             logger.log(Level.SEVERE, "Couldn't obtain mergeable status.", e);
         }
-    }
-
-    private void obtainAuthorEmail(GHPullRequest pr) {
-        try {
-            authorEmail = pr.getUser().getEmail();
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Couldn't obtain author email.", e);
-        }
+        return mergeable;
     }
 
     @Override
@@ -422,11 +409,16 @@ public class GhprbPullRequest {
     }
 
     public String getAuthorEmail() {
-        return authorEmail;
+        try {
+            return pr.getUser().getEmail();
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Unable to fetch author info for " + id);
+        }
+        return "";
     }
 
     public String getTitle() {
-        return title;
+        return pr.getTitle();
     }
 
     /**
@@ -435,7 +427,7 @@ public class GhprbPullRequest {
      * @return the Github Pull Request URL
      */
     public URL getUrl() {
-        return url;
+        return pr.getHtmlUrl();
     }
 
     public GitUser getCommitAuthor() {
@@ -443,7 +435,7 @@ public class GhprbPullRequest {
     }
 
     public GHUser getPullRequestAuthor() {
-        return author;
+        return pr.getUser();
     }
 
     public GHPullRequest getPullRequest() {
@@ -451,6 +443,6 @@ public class GhprbPullRequest {
     }
     
     public String getDescription() {
-        return description;
+        return pr.getBody();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -207,7 +207,11 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     }
 
     Ghprb createGhprb(AbstractProject<?, ?> project) {
-        return new Ghprb(project, this, getDescriptor().getPullRequests(project.getFullName()));
+        return new Ghprb(project, this);
+    }
+    
+    public ConcurrentMap<Integer, GhprbPullRequest> getPulls() {
+        return getDescriptor().getPullRequests(_project.getFullName());
     }
 
     @Override
@@ -845,5 +849,6 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         
     }
+
 
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbWebHook.java
@@ -45,7 +45,7 @@ public class GhprbWebHook {
         repo.onIssueCommentHook(issueComment);
     }
 
-    public void handlePR(PullRequest pr) {
+    public void handlePR(PullRequest pr) throws IOException {
         GhprbRepository repo = trigger.getRepository();
 
         logger.log(Level.INFO, "Checking PR #{0} for job {1}", new Object[] {pr.getNumber(), getProjectName()});

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.ghprb;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kohsuke.github.GHCommitPointer;
@@ -7,6 +8,7 @@ import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
@@ -34,6 +36,16 @@ public class GhprbPullRequestTest {
     private Ghprb helper;
     @Mock
     private GhprbRepository repo;
+    @Mock
+    private GHCommitPointer head;
+    @Mock
+    private GhprbRepository ghprbRepository;
+    
+    @Before
+    public void setup() throws IOException {
+        given(ghprbRepository.getPullRequest(10)).willReturn(pr);
+        given(pr.getHead()).willReturn(head);
+    }
 
     @Test
     public void testConstructorWhenAuthorIsWhitelisted() throws IOException {
@@ -41,6 +53,7 @@ public class GhprbPullRequestTest {
         GHUser ghUser = mock(GHUser.class);
         GHCommitPointer head = mock(GHCommitPointer.class);
         GHCommitPointer base = mock(GHCommitPointer.class);
+        
         given(head.getSha()).willReturn("some sha");
         given(base.getRef()).willReturn("some ref");
 
@@ -96,15 +109,15 @@ public class GhprbPullRequestTest {
         // Mocks for Ghprb
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
-        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
+        GhprbPullRequest ghprbPullRequest = Mockito.spy(new GhprbPullRequest(pr, helper, repo));
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN
         ghprbPullRequest.init(helper, ghprbRepository);
 
         // THEN
-        verify(ghprbRepository, times(1)).getName();
+        verify(ghprbRepository, times(1)).getPullRequest(10);
+        verify(pr, times(2)).getHead();
 
     }
 
@@ -134,7 +147,6 @@ public class GhprbPullRequestTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN
@@ -170,7 +182,6 @@ public class GhprbPullRequestTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN
@@ -210,7 +221,6 @@ public class GhprbPullRequestTest {
         given(helper.isWhitelisted(ghUser)).willReturn(true);
 
         GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
-        GhprbRepository ghprbRepository = mock(GhprbRepository.class);
         given(ghprbRepository.getName()).willReturn("name");
 
         // WHEN

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -503,9 +503,15 @@ public class GhprbRepositoryTest {
         String actualSignature = createSHA1Signature(actualSecret, body);
         String fakeSignature = createSHA1Signature("abc", body);
         
+        GhprbGitHubAuth ghAuth = Mockito.mock(GhprbGitHubAuth.class);
+        doReturn(ghAuth).when(trigger).getGitHubApiAuth();
+        
         Assert.assertFalse(actualSignature.equals(fakeSignature));
-        Assert.assertTrue(GhprbWebHook.checkSignature(body, actualSignature, actualSecret));
-        Assert.assertFalse(GhprbWebHook.checkSignature(body, fakeSignature, actualSecret));
+        
+        given(ghAuth.getSecret()).willReturn(actualSecret);
+        
+        Assert.assertTrue(trigger.getWebHook().checkSignature(body, actualSignature));
+        Assert.assertFalse(trigger.getWebHook().checkSignature(body, fakeSignature));
     }
 
     private String createSHA1Signature(String secret, String body) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -107,6 +107,7 @@ public class GhprbRepositoryTest {
 
         // Mock github API
         given(helper.getGitHub()).willReturn(gitHub);
+        given(helper.getTrigger()).willReturn(trigger);
         given(gitHub.get()).willReturn(gt);
         given(gt.getRepository(anyString())).willReturn(ghRepository);
 
@@ -133,6 +134,7 @@ public class GhprbRepositoryTest {
         given(gt.getRateLimit()).willThrow(new FileNotFoundException());
         List<GHPullRequest> ghPullRequests = createListWithMockPR();
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
 
         mockHeadAndBase();
         mockCommitList();
@@ -156,6 +158,7 @@ public class GhprbRepositoryTest {
         // GIVEN
         List<GHPullRequest> ghPullRequests = createListWithMockPR();
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
 
         mockHeadAndBase();
         mockCommitList();
@@ -178,16 +181,17 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         /** GH PR verifications */
-        verify(ghPullRequest, times(3)).getHead();
-        verify(ghPullRequest, times(1)).getBase();
+        verify(ghPullRequest, times(2)).getHead();
         verify(ghPullRequest, times(2)).getNumber();
         verify(ghPullRequest, times(1)).getUpdatedAt();
+        verify(ghPullRequest, times(1)).getUser();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper).ifOnlyTriggerPhrase();
         verify(helper).getWhiteListTargetBranches();
         verify(helper, times(3)).isProjectDisabled();
         verify(helper).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(2)).getTrigger();
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
@@ -214,7 +218,9 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-
+        given(ghPullRequest.getId()).willReturn(100);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        
         given(ghUser.getEmail()).willReturn("email");
 
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
@@ -225,7 +231,6 @@ public class GhprbRepositoryTest {
         ghprbRepository.check();
 
         // THEN
-
         verifyGetGithub(1);
         verifyNoMoreInteractions(gt);
 
@@ -236,10 +241,10 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(7)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(3)).getBase();
+        verify(ghPullRequest, times(5)).getHead();
+        verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(3)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getHtmlUrl();
@@ -253,9 +258,10 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getWhiteListTargetBranches();
         verify(helper, times(5)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(3)).getTrigger();
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(1)).getEmail(); // Call to Github API
+        verify(ghUser, times(2)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
@@ -281,6 +287,7 @@ public class GhprbRepositoryTest {
 
 
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
+
         given(ghPullRequest.getUpdatedAt()).willReturn(now).willReturn(now).willReturn(tomorrow);
         given(ghPullRequest.getNumber()).willReturn(100);
         given(ghPullRequest.getMergeable()).willReturn(true);
@@ -288,7 +295,9 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-
+        given(ghPullRequest.getId()).willReturn(100);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        
         given(ghUser.getEmail()).willReturn("email");
         given(ghUser.getLogin()).willReturn("login");
 
@@ -312,24 +321,25 @@ public class GhprbRepositoryTest {
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
         verifyNoMoreInteractions(ghRepository);
 
-        verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(1)).getTitle();
+        verify(ghPullRequest, times(8)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(3)).getBase();
+        verify(ghPullRequest, times(5)).getHead();
+        verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(1)).getHtmlUrl();
         verify(ghPullRequest, times(3)).getUpdatedAt();
 
         verify(ghPullRequest, times(1)).getComments();
         verify(ghPullRequest, times(1)).listCommits();
-        verify(ghPullRequest, times(2)).getBody();
+        verify(ghPullRequest, times(1)).getBody();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper, times(1)).isWhitelisted(eq(ghUser)); // Call to Github API
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(4)).getTrigger();
 
         // verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -340,7 +350,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(1)).getEmail(); // Call to Github API
+        verify(ghUser, times(2)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
@@ -363,6 +373,7 @@ public class GhprbRepositoryTest {
         GhprbBuilds builds = mockBuilds();
 
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
+
         given(ghPullRequest.getUpdatedAt()).willReturn(now).willReturn(now).willReturn(tomorrow);
         given(ghPullRequest.getNumber()).willReturn(100);
         given(ghPullRequest.getMergeable()).willReturn(true);
@@ -370,7 +381,9 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-
+        given(ghPullRequest.getId()).willReturn(100);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        
         given(ghUser.getEmail()).willReturn("email");
         given(ghUser.getLogin()).willReturn("login");
 
@@ -398,13 +411,13 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(2)).getUser();
+        verify(ghPullRequest, times(10)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(3)).getBase();
+        verify(ghPullRequest, times(5)).getHead();
+        verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(3)).getUpdatedAt();
-        verify(ghPullRequest, times(1)).getHtmlUrl();
+        verify(ghPullRequest, times(2)).getHtmlUrl();
 
         verify(ghPullRequest, times(1)).getComments();
         verify(ghPullRequest, times(2)).listCommits();
@@ -423,9 +436,10 @@ public class GhprbRepositoryTest {
         verify(helper).isAdmin(eq(ghUser));
         verify(helper, times(6)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(4)).getTrigger();
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(1)).getEmail(); // Call to Github API
+        verify(ghUser, times(3)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
 
@@ -465,6 +479,7 @@ public class GhprbRepositoryTest {
         // GIVEN
         List<GHPullRequest> ghPullRequests = new ArrayList<GHPullRequest>();
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
 
         // WHEN
         ghprbRepository.check();
@@ -475,8 +490,8 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(gt);
 
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
-        verifyNoMoreInteractions(ghRepository);
-        verifyZeroInteractions(helper);
+        verify(helper, times(1)).getTrigger();
+        verifyNoMoreInteractions(helper, ghRepository);
     }
 
     @Test
@@ -540,8 +555,10 @@ public class GhprbRepositoryTest {
         given(head.getSha()).willReturn("head sha");
 
         pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>();
-        ghprbRepository = new GhprbRepository(TEST_USER_NAME, TEST_REPO_NAME, helper, pulls);
+        ghprbRepository = new GhprbRepository(TEST_USER_NAME, TEST_REPO_NAME, helper);
         ghprbPullRequest = new GhprbPullRequest(ghPullRequest, helper, ghprbRepository);
+        
+        given(trigger.getPulls()).willReturn(pulls);
 
         // Reset mocks not to mix init data invocations with tests
         reset(ghPullRequest, ghUser, helper, head, base);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
@@ -97,7 +97,9 @@ public class GhprbRootActionTest {
         given(commitPointer.getSha()).willReturn("sha1");
         GhprbTestUtil.setupGhprbTriggerDescriptor(null);
         project.addProperty(new GithubProjectProperty("https://github.com/user/dropwizard"));
+        given(ghPullRequest.getId()).willReturn(1);
         given(ghPullRequest.getNumber()).willReturn(1);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
         Ghprb ghprb = spy(trigger.createGhprb(project));
         doReturn(ghprbGitHub).when(ghprb).getGitHub();
         trigger.start(project, true);
@@ -137,7 +139,9 @@ public class GhprbRootActionTest {
         given(commitPointer.getSha()).willReturn("sha1");
         GhprbTestUtil.setupGhprbTriggerDescriptor(null);
         project.addProperty(new GithubProjectProperty("https://github.com/user/dropwizard"));
+        given(ghPullRequest.getId()).willReturn(1);
         given(ghPullRequest.getNumber()).willReturn(1);
+        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
         Ghprb ghprb = spy(trigger.createGhprb(project));
         doReturn(ghprbGitHub).when(ghprb).getGitHub();
         trigger.start(project, true);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -21,6 +21,8 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.joda.time.DateTime;
 import org.kohsuke.github.GHCommitPointer;
@@ -38,6 +40,7 @@ import hudson.plugins.git.UserRemoteConfig;
 import net.sf.json.JSONObject;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class GhprbTestUtil {
 
@@ -376,6 +379,10 @@ public class GhprbTestUtil {
         }
         
         GhprbTrigger trigger = spy(req.bindJSON(GhprbTrigger.class, defaults));
+        
+
+        ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
+        Mockito.doReturn(pulls).when(trigger).getPulls();
         
         return trigger;
     }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -346,6 +346,11 @@ public class GhprbTestUtil {
                 null);
     }
     
+
+    public static GhprbTrigger getTrigger() throws Exception {
+        return getTrigger(null);
+    }
+    
     public static GhprbTrigger getTrigger(Map<String, Object> values) throws Exception {
         setupReq();
         if (values == null) {


### PR DESCRIPTION
Change should address #199 and #198.

Events will be parsed once to get the repo, then again before passing down to any relevant jobs.  This allows for authenticating as needed for relevant jobs.