### PR TITLE
Prevent NPE when job started manually

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuildListener.java
@@ -20,7 +20,7 @@ public class GhprbBuildListener extends RunListener<AbstractBuild<?, ?>> {
     @Override
     public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
         GhprbTrigger trigger = Ghprb.extractTrigger(build);
-        if (trigger != null) {
+        if (trigger != null && trigger.getBuilds() != null) {
             trigger.getBuilds().onStarted(build, listener);
         }
     }
@@ -28,7 +28,7 @@ public class GhprbBuildListener extends RunListener<AbstractBuild<?, ?>> {
     @Override
     public void onCompleted(AbstractBuild<?, ?> build, TaskListener listener) {
         GhprbTrigger trigger = Ghprb.extractTrigger(build);
-        if (trigger != null) {
+        if (trigger != null && trigger.getBuilds() != null) {
             trigger.getBuilds().onCompleted(build, listener);
         }
     }
@@ -36,7 +36,7 @@ public class GhprbBuildListener extends RunListener<AbstractBuild<?, ?>> {
     @Override
     public Environment setUpEnvironment(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
         GhprbTrigger trigger = Ghprb.extractTrigger(build);
-        if (trigger != null) {
+        if (trigger != null && trigger.getBuilds() != null) {
             trigger.getBuilds().onEnvironmentSetup(build, launcher, listener);
         }
 


### PR DESCRIPTION
Currently manually started builds fail with NPE:
```
FATAL: null
java.lang.NullPointerException
	at org.jenkinsci.plugins.ghprb.GhprbBuildListener.setUpEnvironment(GhprbBuildListener.java:40)
	at hudson.model.AbstractBuild$AbstractBuildExecution.createLauncher(AbstractBuild.java:575)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:495)
	at hudson.model.Run.execute(Run.java:1741)
	at hudson.matrix.MatrixBuild.run(MatrixBuild.java:301)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:408)
Finished: FAILURE
```