### PR TITLE
Changes getProjectName to check for null from the trigger's getActual…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbWebHook.java
@@ -13,6 +13,8 @@ import org.kohsuke.github.GHEventPayload.IssueComment;
 import org.kohsuke.github.GHEventPayload.PullRequest;
 import org.kohsuke.github.GitHub;
 
+import hudson.model.AbstractProject;
+
 public class GhprbWebHook {
     private static final Logger logger = Logger.getLogger(GhprbWebHook.class.getName());
     
@@ -34,7 +36,16 @@ public class GhprbWebHook {
     }
 
     public String getProjectName() {
-        return trigger.getActualProject().getFullName();
+        AbstractProject<?, ?> actualProject = trigger.getActualProject();
+        // If there was an error in the trigger configuration, getActualProject() could return null.
+        // Avoid the NullPointerException and return null in that case since this method is used
+        // in some catches designed to handle malformed triggers/webhooks.
+        if (actualProject != null) {
+            return actualProject.getFullName();
+        }
+        else {
+            return null;
+        }
     }
 
     public void handleComment(IssueComment issueComment) throws IOException {


### PR DESCRIPTION
…Project()

This isn't a bug per-se, but I have a Jenkins instance configured using the job-dsl plugin.  There was an attempt to configure the ghprb triggers using a configure block (which directly edits xml) which created a somewhat invalid trigger.  There was an error processing the webhooks in GhprbRootAction.doIndex().   The try catch block in the loop caught the exception and should have continued processing the rest of the hooks for other projects, however the catch block calls getProjectName, which has the potential to throw NullPointerException if the project for the trigger can't be found.  Avoid this by checking for whether trigger.getActualProject() return null.