### PR TITLE
Feature/jenkins url override

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For more details, see https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+re
 
 ### Credentials
 * If you are using Enterprise GitHub set the server api URL in ``GitHub server api URL``. Otherwise leave there ``https://api.github.com``.
+* Set the Jenkins URL if you need to override the default (e.g. it's behind a firewall)
 * A GitHub API token or username password can be used for access to the GitHub API
 * To setup credentials for a given GitHub Server API URL:
   * Click Add next to the ``Credentials`` drop down

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
@@ -53,6 +53,7 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     private final String serverAPIUrl;
+    private final String jenkinsUrl;
     private final String credentialsId;
     private final String id;
     private final String description;
@@ -61,6 +62,7 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
     @DataBoundConstructor
     public GhprbGitHubAuth(
             String serverAPIUrl, 
+            String jenkinsUrl, 
             String credentialsId, 
             String description, 
             String id,
@@ -70,6 +72,7 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
             serverAPIUrl = "https://api.github.com";
         }
         this.serverAPIUrl = fixEmptyAndTrim(serverAPIUrl);
+        this.jenkinsUrl = fixEmptyAndTrim(jenkinsUrl);
         this.credentialsId = fixEmpty(credentialsId);
         if (StringUtils.isEmpty(id)) {
             id = UUID.randomUUID().toString();
@@ -83,6 +86,11 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
     @Exported
     public String getServerAPIUrl() {
         return serverAPIUrl;
+    }
+
+    @Exported
+    public String getJenkinsUrl() {
+        return jenkinsUrl;
     }
 
     @Exported

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -262,7 +262,11 @@ public class GhprbRepository {
     }
 
     private static String getHookUrl() {
-        return Jenkins.getInstance().getRootUrl() + GhprbRootAction.URL + "/";
+        String baseUrl = helper.getTrigger().getGitHubApiAuth().getJenkinsURL();
+        if (baseUrl == null) {
+          baseUrl = Jenkins.getInstance().getRootUrl();
+        }
+        return baseUrl + GhprbRootAction.URL + "/";
     }
 
     public GHPullRequest getPullRequest(int id) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -261,8 +261,8 @@ public class GhprbRepository {
         }
     }
 
-    private static String getHookUrl() {
-        String baseUrl = helper.getTrigger().getGitHubApiAuth().getJenkinsURL();
+    private String getHookUrl() {
+        String baseUrl = helper.getTrigger().getGitHubApiAuth().getJenkinsUrl();
         if (baseUrl == null) {
           baseUrl = Jenkins.getInstance().getRootUrl();
         }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -555,7 +555,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         public List<GhprbGitHubAuth> getGithubAuth() {
             if (githubAuth == null || githubAuth.size() == 0) {
                 githubAuth = new ArrayList<GhprbGitHubAuth>(1);
-                githubAuth.add(new GhprbGitHubAuth(null, null, "Anonymous connection", null, null));
+                githubAuth.add(new GhprbGitHubAuth(null, null, null, "Anonymous connection", null, null));
             }
             return githubAuth;
         }
@@ -811,7 +811,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             
             if (!StringUtils.isEmpty(accessToken)) {
                 try {
-                    GhprbGitHubAuth auth = new GhprbGitHubAuth(serverAPIUrl, Ghprb.createCredentials(serverAPIUrl, accessToken), "Pre credentials Token", null, null);
+                    GhprbGitHubAuth auth = new GhprbGitHubAuth(serverAPIUrl, null, Ghprb.createCredentials(serverAPIUrl, accessToken), "Pre credentials Token", null, null);
                     if (githubAuth == null) {
                         githubAuth = new ArrayList<GhprbGitHubAuth>(1);
                     }
@@ -825,7 +825,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             
             if (!StringUtils.isEmpty(username) || !StringUtils.isEmpty(password)) {
                 try {
-                    GhprbGitHubAuth auth = new GhprbGitHubAuth(serverAPIUrl, Ghprb.createCredentials(serverAPIUrl, username, password), "Pre credentials username and password", null, null);
+                    GhprbGitHubAuth auth = new GhprbGitHubAuth(serverAPIUrl, null, Ghprb.createCredentials(serverAPIUrl, username, password), "Pre credentials username and password", null, null);
                     if (githubAuth == null) {
                         githubAuth = new ArrayList<GhprbGitHubAuth>(1);
                     }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth/config.groovy
@@ -5,7 +5,7 @@ f.entry(title:_("GitHub Server API URL"), field:"serverAPIUrl") {
     f.textbox()
 }
 
-ff.entry(title:_("Jenkins URL override"), field:"jenkinsUrl") {
+f.entry(title:_("Jenkins URL override"), field:"jenkinsUrl") {
     f.textbox()
 }
 

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth/config.groovy
@@ -5,6 +5,10 @@ f.entry(title:_("GitHub Server API URL"), field:"serverAPIUrl") {
     f.textbox()
 }
 
+ff.entry(title:_("Jenkins URL override"), field:"jenkinsUrl") {
+    f.textbox()
+}
+
 f.entry(title:_("Shared secret"), field:"secret") {
     f.password()
 }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth/help-jenkinsUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth/help-jenkinsUrl.html
@@ -1,0 +1,3 @@
+<div>
+    Use this to override the Jenkins URL that GitHub should call.
+</div>


### PR DESCRIPTION
This is the first bit of Java I've C&P so I maybe doing things wrong, however it seems to work for me.  This resolves #220 so that you can specify a non-default URL for github to send requests to (which is required in some cases - e.g. if you have an internal and external jenkins URL that differ)