### PR TITLE
set shared secret in webhook

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -251,14 +251,22 @@ public class GhprbRepository {
                 return true;
             }
             Map<String, String> config = new HashMap<String, String>();
+            String secret = getSecret();
             config.put("url", new URL(getHookUrl()).toExternalForm());
             config.put("insecure_ssl", "1");
+            if (secret != "") {
+             config.put("secret",secret);
+            }
             ghRepository.createHook("web", config, HOOK_EVENTS, true);
             return true;
         } catch (IOException ex) {
             logger.log(Level.SEVERE, "Couldn''t create web hook for repository {0}. Does the user (from global configuration) have admin rights to the repository?", reponame);
             return false;
         }
+    }
+
+    private String getSecret() {
+        return helper.getTrigger().getGitHubApiAuth().getSecret();
     }
 
     private static String getHookUrl() {


### PR DESCRIPTION
When using a differnet jenkins url (see https://github.com/jenkinsci/ghprb-plugin/pull/223) the shared secret wasn't being set in the github URL.  As such any received requests came through with:

SEVERE: Request doesn't contain a signature. Check that github has a secret that should be attached
to the hook

This adds the secret. Not sure how this worked beforehand - maybe it wasn't tested with autocreated hooks?
