### PR TITLE
During init, we should check whether initGhRepository returns false

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -44,7 +44,12 @@ public class GhprbRepository {
 
     public void init() {
         // make the initial check call to populate our data structures
-        initGhRepository();
+        if (!initGhRepository()) {
+            // We could have hit the rate limit while initializing.  If we
+            // continue, then we will loop back around and attempt to re-init.
+            return;
+        }
+        
         for (Entry<Integer, GhprbPullRequest> next : helper.getTrigger().getPulls().entrySet()) {
             GhprbPullRequest pull = next.getValue();
             try {


### PR DESCRIPTION
If it returns false, then ghRepository will not be set, which will cause us to eventually loop around and attempt to call init again (and again)