### PR TITLE
[JENKINS-31214] added Job DSL for GhprbTrigger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
             <version>1.3</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>job-dsl</artifactId>
+            <version>1.39</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.ghprb.jobdsl;
+
+import antlr.ANTLRException;
+import com.google.common.base.Joiner;
+import hudson.Extension;
+import javaposse.jobdsl.dsl.DslException;
+import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import javaposse.jobdsl.plugin.DslExtensionMethod;
+import org.jenkinsci.plugins.ghprb.GhprbBranch;
+import org.jenkinsci.plugins.ghprb.GhprbTrigger;
+
+import java.util.ArrayList;
+
+@Extension(optional = true)
+public class GhprbContextExtensionPoint extends ContextExtensionPoint {
+    @DslExtensionMethod(context = TriggerContext.class)
+    public Object githubPullRequest(Runnable closure) {
+        GhprbTriggerContext context = new GhprbTriggerContext();
+        executeInContext(closure, context);
+        try {
+            return new GhprbTrigger(
+                    Joiner.on("\n").join(context.admins),
+                    Joiner.on("\n").join(context.userWhitelist),
+                    Joiner.on("\n").join(context.orgWhitelist),
+                    context.cron,
+                    context.triggerPhrase,
+                    context.onlyTriggerPhrase,
+                    context.useGitHubHooks,
+                    context.permitAll,
+                    context.autoCloseFailedPullRequests,
+                    null,
+                    null,
+                    new ArrayList<GhprbBranch>(),
+                    context.allowMembersOfWhitelistedOrgsAsAdmin,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    context.extensionContext.extensions
+            );
+        } catch (ANTLRException e) {
+            throw new DslException("invalid cron tab", e);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.ghprb.jobdsl;
 import antlr.ANTLRException;
 import com.google.common.base.Joiner;
 import hudson.Extension;
-import javaposse.jobdsl.dsl.DslException;
 import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
@@ -15,33 +14,29 @@ import java.util.ArrayList;
 @Extension(optional = true)
 public class GhprbContextExtensionPoint extends ContextExtensionPoint {
     @DslExtensionMethod(context = TriggerContext.class)
-    public Object githubPullRequest(Runnable closure) {
+    public Object githubPullRequest(Runnable closure) throws ANTLRException {
         GhprbTriggerContext context = new GhprbTriggerContext();
         executeInContext(closure, context);
-        try {
-            return new GhprbTrigger(
-                    Joiner.on("\n").join(context.admins),
-                    Joiner.on("\n").join(context.userWhitelist),
-                    Joiner.on("\n").join(context.orgWhitelist),
-                    context.cron,
-                    context.triggerPhrase,
-                    context.onlyTriggerPhrase,
-                    context.useGitHubHooks,
-                    context.permitAll,
-                    context.autoCloseFailedPullRequests,
-                    null,
-                    null,
-                    new ArrayList<GhprbBranch>(),
-                    context.allowMembersOfWhitelistedOrgsAsAdmin,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    context.extensionContext.extensions
-            );
-        } catch (ANTLRException e) {
-            throw new DslException("invalid cron tab", e);
-        }
+        return new GhprbTrigger(
+                Joiner.on("\n").join(context.admins),
+                Joiner.on("\n").join(context.userWhitelist),
+                Joiner.on("\n").join(context.orgWhitelist),
+                context.cron,
+                context.triggerPhrase,
+                context.onlyTriggerPhrase,
+                context.useGitHubHooks,
+                context.permitAll,
+                context.autoCloseFailedPullRequests,
+                null,
+                null,
+                new ArrayList<GhprbBranch>(),
+                context.allowMembersOfWhitelistedOrgsAsAdmin,
+                null,
+                null,
+                null,
+                null,
+                null,
+                context.extensionContext.extensions
+        );
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbExtensionContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbExtensionContext.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.ghprb.jobdsl;
+
+import javaposse.jobdsl.dsl.Context;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
+import org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class GhprbExtensionContext implements Context {
+    List<GhprbExtension> extensions = new ArrayList<GhprbExtension>();
+
+    /**
+     * Updates the commit status during the build.
+     */
+    void commitStatus(Runnable closure) {
+        GhprbSimpleStatusContext context = new GhprbSimpleStatusContext();
+        ContextExtensionPoint.executeInContext(closure, context);
+
+        extensions.add(new GhprbSimpleStatus(
+                context.context,
+                context.statusUrl,
+                context.triggeredStatus,
+                context.startedStatus,
+                context.completedStatus
+        ));
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbSimpleStatusContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbSimpleStatusContext.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.ghprb.jobdsl;
+
+import javaposse.jobdsl.dsl.Context;
+import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage;
+import org.kohsuke.github.GHCommitState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class GhprbSimpleStatusContext implements Context {
+    String context;
+    String triggeredStatus;
+    String startedStatus;
+    String statusUrl;
+    List<GhprbBuildResultMessage> completedStatus = new ArrayList<GhprbBuildResultMessage>();
+
+    /**
+     * A string label to differentiate this status from the status of other systems.
+     */
+    void context(String context) {
+        this.context = context;
+    }
+
+    /**
+     * Use a custom status for when a build is triggered.
+     */
+    void triggeredStatus(String triggeredStatus) {
+        this.triggeredStatus = triggeredStatus;
+    }
+
+    /**
+     * Use a custom status for when a build is started.
+     */
+    void startedStatus(String startedStatus) {
+        this.startedStatus = startedStatus;
+    }
+
+    /**
+     * Use a custom URL instead of the job default.
+     */
+    void statusUrl(String statusUrl) {
+        this.statusUrl = statusUrl;
+    }
+
+    /**
+     * Use a custom status for when a build is completed. Can be called multiple times to set messages for different
+     * build results. Valid build results are {@code 'SUCCESS'}, {@code 'FAILURE'}, and {@code 'ERROR'}.
+     */
+    void completedStatus(String buildResult, String message) {
+        completedStatus.add(new GhprbBuildResultMessage(
+                GHCommitState.valueOf(buildResult),
+                message
+        ));
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -1,0 +1,161 @@
+package org.jenkinsci.plugins.ghprb.jobdsl;
+
+import javaposse.jobdsl.dsl.Context;
+import javaposse.jobdsl.dsl.helpers.triggers.GitHubPullRequestBuilderExtensionContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class GhprbTriggerContext implements Context {
+    List<String> admins = new ArrayList<String>();
+    List<String> userWhitelist = new ArrayList<String>();
+    List<String> orgWhitelist = new ArrayList<String>();
+    String cron = "H/5 * * * *";
+    String triggerPhrase;
+    boolean onlyTriggerPhrase;
+    boolean useGitHubHooks;
+    boolean permitAll;
+    boolean autoCloseFailedPullRequests;
+    boolean allowMembersOfWhitelistedOrgsAsAdmin;
+    GhprbExtensionContext extensionContext = new GhprbExtensionContext();
+
+    /**
+     * Adds admins for this job.
+     */
+    public void admin(String admin) {
+        admins.add(admin);
+    }
+
+    /**
+     * Adds admins for this job.
+     */
+    public void admins(Iterable<String> admins) {
+        for (String admin : admins) {
+            admin(admin);
+        }
+    }
+
+    /**
+     * Adds whitelisted users for this job.
+     */
+    public void userWhitelist(String user) {
+        userWhitelist.add(user);
+    }
+
+    /**
+     * Adds whitelisted users for this job.
+     */
+    public void userWhitelist(Iterable<String> users) {
+        for (String user : users) {
+            userWhitelist(user);
+        }
+    }
+
+    /**
+     * Adds organisation names whose members are considered whitelisted for this specific job.
+     */
+    public void orgWhitelist(String organization) {
+        orgWhitelist.add(organization);
+    }
+
+    /**
+     * Adds organisation names whose members are considered whitelisted for this specific job.
+     */
+    public void orgWhitelist(Iterable<String> organizations) {
+        for (String organization : organizations) {
+            orgWhitelist(organization);
+        }
+    }
+
+    /**
+     * This schedules polling to GitHub for new changes in pull requests.
+     */
+    public void cron(String cron) {
+        this.cron = cron;
+    }
+
+    /**
+     * When filled, commenting this phrase in the pull request will trigger a build.
+     */
+    public void triggerPhrase(String triggerPhrase) {
+        this.triggerPhrase = triggerPhrase;
+    }
+
+    /**
+     * When set, only commenting the trigger phrase in the pull request will trigger a build.
+     */
+    public void onlyTriggerPhrase(boolean onlyTriggerPhrase) {
+        this.onlyTriggerPhrase = onlyTriggerPhrase;
+    }
+
+    /**
+     * When set, only commenting the trigger phrase in the pull request will trigger a build.
+     */
+    public void onlyTriggerPhrase() {
+        onlyTriggerPhrase(true);
+    }
+
+    /**
+     * Checking this option will disable regular polling for changes in GitHub and will try to create a GitHub hook.
+     */
+    public void useGitHubHooks(boolean useGitHubHooks) {
+        this.useGitHubHooks = useGitHubHooks;
+    }
+
+    /**
+     * Checking this option will disable regular polling for changes in GitHub and will try to create a GitHub hook.
+     */
+    public void useGitHubHooks() {
+        useGitHubHooks(true);
+    }
+
+    /**
+     * Build every pull request automatically without asking.
+     */
+    public void permitAll(boolean permitAll) {
+        this.permitAll = permitAll;
+    }
+
+    /**
+     * Build every pull request automatically without asking.
+     */
+    public void permitAll() {
+        permitAll(true);
+    }
+
+    /**
+     * Close pull request automatically when the build fails.
+     */
+    public void autoCloseFailedPullRequests(boolean autoCloseFailedPullRequests) {
+        this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
+    }
+
+    /**
+     * Close pull request automatically when the build fails.
+     */
+    public void autoCloseFailedPullRequests() {
+        autoCloseFailedPullRequests(true);
+    }
+
+    /**
+     * Allows members of whitelisted organisations to behave like admins.
+     */
+    public void allowMembersOfWhitelistedOrgsAsAdmin(boolean allowMembersOfWhitelistedOrgsAsAdmin) {
+        this.allowMembersOfWhitelistedOrgsAsAdmin = allowMembersOfWhitelistedOrgsAsAdmin;
+    }
+
+    /**
+     * Allows members of whitelisted organisations to behave like admins.
+     */
+    public void allowMembersOfWhitelistedOrgsAsAdmin() {
+        allowMembersOfWhitelistedOrgsAsAdmin(true);
+    }
+
+    /**
+     * Adds additional trigger options.
+     */
+    public void extensions(Runnable closure) {
+        ContextExtensionPoint.executeInContext(closure, extensionContext);
+    }
+}


### PR DESCRIPTION
This is the first step to move the Job DSL for GhprbTrigger from the Job DSL Plugin to the GitHub Pull Request Builder plugin.

I copied the existing DSL syntax to keep compatibility, only the `pullRequest` method has been renamed to `githubPullRequest` to avoid confusion with other pull request builder plugins.

DSL example:
```groovy
job('example') {
    triggers {
        githubPullRequest {
            admin('USER_ID')
            userWhitelist('you@you.com')
            orgWhitelist(['your_github_org', 'another_org'])
            cron('H/5 * * * *')
            triggerPhrase('Ok to test')
            onlyTriggerPhrase()
            useGitHubHooks()
            permitAll()
            autoCloseFailedPullRequests()
            allowMembersOfWhitelistedOrgsAsAdmin()
            extensions {
                commitStatus {
                    context('deploy to staging site')
                    startedStatus('deploying to staging site...')
                    statusUrl('http://mystatussite.com/prs')
                    completedStatus('SUCCESS', 'All is well')
                    completedStatus('FAILURE', 'Something went wrong. Investigate!')
                }
            }
        }
    }
}
```