### PR TITLE
[JENKINS-31827] Use default timeouts for URLConnections

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/HttpConnectorWithJenkinsProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/HttpConnectorWithJenkinsProxy.java
@@ -1,14 +1,24 @@
 package org.jenkinsci.plugins.ghprb;
 
-import hudson.ProxyConfiguration;
-import org.kohsuke.github.HttpConnector;
-
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import org.kohsuke.github.HttpConnector;
+
+import hudson.ProxyConfiguration;
+
 public class HttpConnectorWithJenkinsProxy implements HttpConnector {
     public HttpURLConnection connect(URL url) throws IOException {
-        return (HttpURLConnection) ProxyConfiguration.open(url);
+        HttpURLConnection con = (HttpURLConnection) ProxyConfiguration.open(url);
+
+        // Set default timeouts in case there are none
+        if (con.getConnectTimeout() == 0) {
+            con.setConnectTimeout(10000);
+        }
+        if (con.getReadTimeout() == 0) {
+            con.setReadTimeout(10000);
+        }
+        return con;
     }
 }


### PR DESCRIPTION
[JENKINS-31827](https://issues.jenkins-ci.org/browse/JENKINS-31827)