### PR TITLE
Fix config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -631,6 +631,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
             try {
                 extensions.rebuildHetero(req, formData, getGlobalExtensionDescriptors(), "extensions");
+                // Now make sure we have at least one of the types we need one of.
+                Ghprb.addIfMissing(this.extensions, new GhprbSimpleStatus(), GhprbCommitStatus.class);
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Fixed janinko/ghprb#372
Fixed janinko/ghprb#351

The problem was in trying to get the global if there wasn't a local configuration setup.  The update is required, but can be set up in a way so that it doesn't actually update the commit status.