### PR TITLE
JENKINS-32375: GHPRB - Add DSL Support for Downstream Commit Status and Whitelist Target Branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,13 @@ If you want to manually build the job, in the job setting check ``This build is 
 Since the plugin contains an extension for the Job DSL plugin to add DSL syntax for configuring the build trigger and
 the pull request merger post-build action.
 
+It is also possible to set Downstream job commit statuses when `displayBuildErrorsOnDownstreamBuilds()` is set in the
+upstream job's triggers and downstreamCommitStatus block is included in the downstream job's wrappers.
+
 Here is an example showing all DSL syntax elements:
 
 ```groovy
-job('example') {
+job('upstreamJob') {
     scm {
         git {
             remote {
@@ -123,6 +126,7 @@ job('example') {
             branch('${sha1}')
         }
     }
+
     triggers {
         githubPullRequest {
             admin('user_1')
@@ -137,6 +141,8 @@ job('example') {
             useGitHubHooks()
             permitAll()
             autoCloseFailedPullRequests()
+            displayBuildErrorsOnDownstreamBuilds()
+            whiteListTargetBranches(['master','test', 'test2'])
             allowMembersOfWhitelistedOrgsAsAdmin()
             extensions {
                 commitStatus {
@@ -159,6 +165,20 @@ job('example') {
             disallowOwnCode()
             failOnNonMerge()
             deleteOnMerge()
+        }
+    }
+}
+
+job('downstreamJob') {
+    wrappers {
+        downstreamCommitStatus {
+            context('CONTEXT NAME')
+            triggeredStatus("The job has triggered")
+            startedStatus("The job has started")
+            statusUrl()
+            completedStatus('SUCCESS', "The job has passed")
+            completedStatus('FAILURE', "The job has failed")
+            completedStatus('ERROR', "The job has resulted in an error")
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -5,11 +5,13 @@ import com.google.common.base.Joiner;
 import hudson.Extension;
 import javaposse.jobdsl.dsl.helpers.publisher.PublisherContext;
 import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext;
+import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
 import org.jenkinsci.plugins.ghprb.GhprbBranch;
 import org.jenkinsci.plugins.ghprb.GhprbPullRequestMerge;
 import org.jenkinsci.plugins.ghprb.GhprbTrigger;
+import org.jenkinsci.plugins.ghprb.upstream.GhprbUpstreamStatus;
 
 import java.util.ArrayList;
 
@@ -29,9 +31,9 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 context.useGitHubHooks,
                 context.permitAll,
                 context.autoCloseFailedPullRequests,
+                context.displayBuildErrorsOnDownstreamBuilds,
                 null,
-                null,
-                new ArrayList<GhprbBranch>(),
+                context.whiteListTargetBranches,
                 context.allowMembersOfWhitelistedOrgsAsAdmin,
                 null,
                 null,
@@ -53,6 +55,20 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 context.disallowOwnCode,
                 context.failOnNonMerge,
                 context.deleteOnMerge
+        );
+    }
+
+    @DslExtensionMethod(context = WrapperContext.class)
+    public Object downstreamCommitStatus(Runnable closure) {
+        GhprbUpstreamStatusContext context = new GhprbUpstreamStatusContext();
+        executeInContext(closure, context);
+
+        return new GhprbUpstreamStatus(
+                context.context,
+                context.statusUrl,
+                context.triggeredStatus,
+                context.startedStatus,
+                context.completedStatus
         );
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.ghprb.jobdsl;
 
 import javaposse.jobdsl.dsl.Context;
-import javaposse.jobdsl.dsl.helpers.triggers.GitHubPullRequestBuilderExtensionContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import org.jenkinsci.plugins.ghprb.GhprbBranch;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +11,7 @@ class GhprbTriggerContext implements Context {
     List<String> admins = new ArrayList<String>();
     List<String> userWhitelist = new ArrayList<String>();
     List<String> orgWhitelist = new ArrayList<String>();
+    List<GhprbBranch> whiteListTargetBranches = new ArrayList<GhprbBranch>();
     String cron = "H/5 * * * *";
     String triggerPhrase;
     boolean onlyTriggerPhrase;
@@ -18,6 +19,7 @@ class GhprbTriggerContext implements Context {
     boolean permitAll;
     boolean autoCloseFailedPullRequests;
     boolean allowMembersOfWhitelistedOrgsAsAdmin;
+    boolean displayBuildErrorsOnDownstreamBuilds;
     GhprbExtensionContext extensionContext = new GhprbExtensionContext();
 
     /**
@@ -65,6 +67,23 @@ class GhprbTriggerContext implements Context {
     public void orgWhitelist(Iterable<String> organizations) {
         for (String organization : organizations) {
             orgWhitelist(organization);
+        }
+    }
+
+
+    /**
+     * Add branch names whose they are considered whitelisted for this specific job
+     */
+    public void whiteListTargetBranch(String branch) {
+        whiteListTargetBranches.add(new GhprbBranch(branch));
+    }
+
+    /**
+     * Add branch names whose they are considered whitelisted for this specific job
+     */
+    public void whiteListTargetBranches(Iterable<String> branches) {
+        for (String branch : branches) {
+            whiteListTargetBranches.add(new GhprbBranch(branch));
         }
     }
 
@@ -150,6 +169,20 @@ class GhprbTriggerContext implements Context {
      */
     public void allowMembersOfWhitelistedOrgsAsAdmin() {
         allowMembersOfWhitelistedOrgsAsAdmin(true);
+    }
+
+    /**
+     * Allow this upstream job to get commit statuses from downstream builds
+     */
+    public void displayBuildErrorsOnDownstreamBuilds(boolean displayBuildErrorsOnDownstreamBuilds) {
+        this.displayBuildErrorsOnDownstreamBuilds = displayBuildErrorsOnDownstreamBuilds;
+    }
+
+    /**
+     * Allow this upstream job to get commit statuses from downstream builds
+     */
+    public void displayBuildErrorsOnDownstreamBuilds() {
+        displayBuildErrorsOnDownstreamBuilds(true);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbUpstreamStatusContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbUpstreamStatusContext.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.ghprb.jobdsl;
+
+import javaposse.jobdsl.dsl.Context;
+import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage;
+import org.kohsuke.github.GHCommitState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class GhprbUpstreamStatusContext implements Context {
+    String context;
+    String triggeredStatus;
+    String startedStatus;
+    String statusUrl;
+    List<GhprbBuildResultMessage> completedStatus = new ArrayList<GhprbBuildResultMessage>();
+
+    /**
+     * A string label to differentiate this status from the status of other systems.
+     */
+    void context(String context) {
+        this.context = context;
+    }
+
+    /**
+     * Use a custom status for when a build is triggered.
+     */
+    void triggeredStatus(String triggeredStatus) {
+        this.triggeredStatus = triggeredStatus;
+    }
+
+    /**
+     * Use a custom status for when a build is started.
+     */
+    void startedStatus(String startedStatus) {
+        this.startedStatus = startedStatus;
+    }
+
+    /**
+     * Use a custom URL instead of the job default.
+     */
+    void statusUrl(String statusUrl) {
+        this.statusUrl = statusUrl;
+    }
+
+    /**
+     * Use a custom status for when a build is completed. Can be called multiple times to set messages for different
+     * build results. Valid build results are {@code 'SUCCESS'}, {@code 'FAILURE'}, and {@code 'ERROR'}.
+     */
+    void completedStatus(String buildResult, String message) {
+        completedStatus.add(new GhprbBuildResultMessage(
+                GHCommitState.valueOf(buildResult),
+                message
+        ));
+    }
+}


### PR DESCRIPTION
1) Added displayBuildErrorsOnDownstreamBuilds and whiteListTargetBranches DSL fields for setting the upstream job with triggering commit statuses from downstream jobs and setting whitelisted branches
```
githubPullRequest {
  cron('*/1 * * * *')
  useGitHubHooks()
  permitAll()
  displayBuildErrorsOnDownstreamBuilds() // New: Used for enabling commit statuses from downstream jobs
  whiteListTargetBranches(['master','test', 'test2']) // New: Used for creating whiteList TargetBranches
}
```

2) Added new DslExtensionMethod for setting the commit status for downstream jobs
```
downstreamCommitStatus {
  context('CONTEXT NAME')
  triggeredStatus("The job has triggered")
  startedStatus("The job has started")
  statusUrl()
  completedStatus('SUCCESS', "The job has passed")
  completedStatus('FAILURE', "The job has failed")
  completedStatus('ERROR', "The job has resulted in an error")
}
```
3) Updated README