### PR TITLE
Fixed NPE when no build result message is set on Jenkins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus.java
@@ -39,7 +39,7 @@ public class GhprbUpstreamStatus extends BuildWrapper {
         
         Map<GHCommitState, StringBuilder> statusMessages = new HashMap<GHCommitState, StringBuilder>(5);
         
-        for (GhprbBuildResultMessage message : completedStatus) {
+        for (GhprbBuildResultMessage message : getCompletedStatus()) {
             GHCommitState state = message.getResult();
             StringBuilder sb;
             if (!statusMessages.containsKey(state)) {


### PR DESCRIPTION
When no build result message is set, the `completedStatus` variable appears to be `null`, making the plugin crash with the following stack trace:

```
java.lang.NullPointerException
	at org.jenkinsci.plugins.ghprb.upstream.GhprbUpstreamStatus.makeBuildVariables(GhprbUpstreamStatus.java:42)
	at hudson.model.AbstractBuild.getBuildVariables(AbstractBuild.java:1056)
	at org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter.getBuildVariables(EnvInjectVariableGetter.java:108)
	at org.jenkinsci.plugins.envinject.EnvInjectListener.setUpEnvironmentWithoutJobPropertyObject(EnvInjectListener.java:233)
	at org.jenkinsci.plugins.envinject.EnvInjectListener.setUpEnvironment(EnvInjectListener.java:46)
	at hudson.model.AbstractBuild$AbstractBuildExecution.createLauncher(AbstractBuild.java:572)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:492)
	at hudson.model.Run.execute(Run.java:1738)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:410)
ERROR: Build step failed with exception
```

By applying this change, the variable in the for loop condition cannot be `null` anymore since it uses the local `getCompletedStatus()` method.