### PR TITLE
Use message metadata to determine whether issue_comment is pull request

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -102,6 +102,11 @@ public class GhprbRootAction implements UnprotectedRootAction {
                     logger.log(Level.INFO, "Skip comment on closed PR");
                     return;
                 }
+                
+                if (!issueComment.getIssue().isPullRequest()) {
+                    logger.log(Level.INFO, "Skip comment on Issue");
+                    return;
+                }
 
                 String repoName = issueComment.getRepository().getFullName();
 


### PR DESCRIPTION
Avoids a lot of unneeded API calls that will return 404