### PR TITLE
Move PR data to its own config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -64,7 +64,7 @@ public class Ghprb {
     }
     
     public boolean isProjectDisabled() {
-        return trigger.getActualProject().isDisabled();
+        return !trigger.isActive();
     }
 
     public GhprbBuilds getBuilds() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -109,7 +109,6 @@ public class GhprbPullRequestMerge extends Recorder {
 
         if (helper == null) {
             helper = new Ghprb(trigger);
-            helper.init();
         }
 
         GHUser triggerSender = cause.getTriggerSender();
@@ -209,7 +208,7 @@ public class GhprbPullRequestMerge extends Recorder {
 
     private void commentOnRequest(String comment) {
         try {
-            helper.getRepository().addComment(pr.getNumber(), comment);
+            trigger.getRepository().addComment(pr.getNumber(), comment);
         } catch (Exception e) {
             logger.println("Failed to add comment");
             e.printStackTrace(logger);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -387,9 +387,8 @@ public class GhprbRepository implements Saveable{
         XmlFile xml = getConfigXml(trigger.getActualProject());
         if(xml.exists()){
             xml.unmarshal(this);
-        } else {
-            save();
         }
+        save();
     }
 
     public void save() throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -1,49 +1,76 @@
 package org.jenkinsci.plugins.ghprb;
 
+import hudson.BulkChange;
+import hudson.XmlFile;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Items;
+import hudson.model.Saveable;
 import hudson.model.TaskListener;
+import hudson.model.listeners.SaveableListener;
 import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus;
-import org.kohsuke.github.*;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.github.GHEvent;
 import org.kohsuke.github.GHEventPayload.IssueComment;
 import org.kohsuke.github.GHEventPayload.PullRequest;
+import org.kohsuke.github.GHHook;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.util.*;
+import java.net.URLEncoder;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
  * @author Honza Brázdil <jbrazdil@redhat.com>
  */
-public class GhprbRepository {
+public class GhprbRepository implements Saveable{
 
-    private static final Logger logger = Logger.getLogger(GhprbRepository.class.getName());
-    private static final EnumSet<GHEvent> HOOK_EVENTS = EnumSet.of(GHEvent.ISSUE_COMMENT, GHEvent.PULL_REQUEST);
+    private static final transient Logger logger = Logger.getLogger(GhprbRepository.class.getName());
+    private static final transient EnumSet<GHEvent> HOOK_EVENTS = EnumSet.of(GHEvent.ISSUE_COMMENT, GHEvent.PULL_REQUEST);
 
     private final String reponame;
 
-    private GHRepository ghRepository;
-    private GhprbTrigger trigger;
+    private transient GHRepository ghRepository;
+    private transient GhprbTrigger trigger;
+    private final Map<Integer, GhprbPullRequest> pullRequests;
 
-    public GhprbRepository(String user, String repository, GhprbTrigger trigger) {
-        this.reponame = user + "/" + repository;
+    public GhprbRepository(String reponame, GhprbTrigger trigger) {
+        this.pullRequests = new ConcurrentHashMap<Integer, GhprbPullRequest>();
+        this.reponame = reponame;
         this.trigger = trigger;
     }
-
+    
+    public void addPullRequests(Map<Integer, GhprbPullRequest> prs) {
+        pullRequests.putAll(prs);
+    }
+    
     public void init() {
         // make the initial check call to populate our data structures
         initGhRepository();
         
-        for (Entry<Integer, GhprbPullRequest> next : trigger.getPullRequests().entrySet()) {
+        for (Entry<Integer, GhprbPullRequest> next : pullRequests.entrySet()) {
             GhprbPullRequest pull = next.getValue();
             pull.init(trigger.getHelper(), this);
         }
@@ -101,23 +128,24 @@ public class GhprbRepository {
         if (!initGhRepository()) {
             return;
         }
+        
+        GHRepository repo = getGitHubRepo();
 
         List<GHPullRequest> openPulls;
         try {
-            openPulls = getGitHubRepo().getPullRequests(GHIssueState.OPEN);
+            openPulls = repo.getPullRequests(GHIssueState.OPEN);
         } catch (IOException ex) {
             logger.log(Level.SEVERE, "Could not retrieve open pull requests.", ex);
             return;
         }
         
-        Map<Integer, GhprbPullRequest> pulls = trigger.getPullRequests();
         
-        Set<Integer> closedPulls = new HashSet<Integer>(pulls.keySet());
+        Set<Integer> closedPulls = new HashSet<Integer>(pullRequests.keySet());
 
         for (GHPullRequest pr : openPulls) {
             if (pr.getHead() == null) { // Not sure if we need this, but leaving it for now.
                 try {
-                    pr = getGitHubRepo().getPullRequest(pr.getNumber());
+                    pr = getPullRequest(pr.getNumber());
                 } catch (IOException ex) {
                     logger.log(Level.SEVERE, "Could not retrieve pr " + pr.getNumber(), ex);
                     return;
@@ -130,9 +158,13 @@ public class GhprbRepository {
 
         // remove closed pulls so we don't check them again
         for (Integer id : closedPulls) {
-            pulls.remove(id);
+            pullRequests.remove(id);
         }
-        trigger.save();
+        try {
+            this.save();
+        } catch (IOException e) {
+           logger.log(Level.SEVERE, "Unable to save repository!", e);
+        }
     }
 
     private void check(GHPullRequest pr, boolean isNew) {
@@ -143,7 +175,11 @@ public class GhprbRepository {
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Unable to check pr: " + number, e);
         }
-        trigger.save();
+        try {
+            this.save();
+        } catch (IOException e) {
+           logger.log(Level.SEVERE, "Unable to save repository!", e);
+        }
     }
 
     public void commentOnFailure(AbstractBuild<?, ?> build, TaskListener listener, GhprbCommitStatusException ex) {
@@ -296,23 +332,26 @@ public class GhprbRepository {
 
         GhprbPullRequest pull = getPullRequest(null, false, number);
         pull.check(issueComment.getComment());
-        trigger.save();
+        try {
+            this.save();
+        } catch (IOException e) {
+           logger.log(Level.SEVERE, "Unable to save repository!", e);
+        }
     }
     
     private GhprbPullRequest getPullRequest(GHPullRequest ghpr, Boolean isNew, Integer number) throws IOException {
-        Map<Integer, GhprbPullRequest> prs = trigger.getPullRequests();
         if (number == null) {
             number = ghpr.getNumber();
         }
-        synchronized (prs) {
-            GhprbPullRequest pr = prs.get(number);
+        synchronized (pullRequests) {
+            GhprbPullRequest pr = pullRequests.get(number);
             if (pr == null) {
                 if (ghpr == null) {
                     GHRepository repo = getGitHubRepo();
                     ghpr = repo.getPullRequest(number);
                 }
                 pr = new GhprbPullRequest(ghpr, trigger.getHelper(), this, isNew);
-                prs.put(number, pr);
+                pullRequests.put(number, pr);
             }
             
             return pr;
@@ -324,10 +363,9 @@ public class GhprbRepository {
         int number = pr.getNumber();
         String action = pr.getAction();
 
-        Map<Integer, GhprbPullRequest> pulls = trigger.getPullRequests();
 
         if ("closed".equals(action)) {
-            pulls.remove(number);
+            pullRequests.remove(number);
         } else if (!trigger.isActive()) {
             logger.log(Level.FINE, "Not processing Pull request since the build is disabled");
         } else if ("opened".equals(action) || "reopened".equals(action) || "synchronize".equals(action)) {
@@ -343,5 +381,33 @@ public class GhprbRepository {
             initGhRepository();
         }
         return ghRepository;
+    }
+
+    public void load() throws IOException {
+        XmlFile xml = getConfigXml(trigger.getActualProject());
+        if(xml.exists()){
+            xml.unmarshal(this);
+        } else {
+            save();
+        }
+    }
+
+    public void save() throws IOException {
+        if(BulkChange.contains(this)) {
+            return;
+        }
+        XmlFile config = getConfigXml(trigger.getActualProject());
+        config.write(this);
+        SaveableListener.fireOnChange(this, config);
+    }
+
+    protected XmlFile getConfigXml(AbstractProject<?, ?> project) throws IOException {
+        try {
+            String escapedRepoName = URLEncoder.encode(reponame, "UTF8");
+            File file = new File(project.getBuildDir() + "/pullrequests", escapedRepoName);
+            return Items.getConfigFile(file);
+        } catch (UnsupportedEncodingException e) {
+            throw new IOException(e);
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTriggerBackwardsCompatible.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTriggerBackwardsCompatible.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.ghprb;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
@@ -47,6 +48,8 @@ public abstract class GhprbTriggerBackwardsCompatible extends Trigger<AbstractPr
     protected transient String project;
     @Deprecated
     protected transient AbstractProject<?, ?> _project;
+    @Deprecated
+    protected transient Map<Integer, GhprbPullRequest> pullRequests;
     
 
     

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -8,12 +8,10 @@ import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext;
 import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
-import org.jenkinsci.plugins.ghprb.GhprbBranch;
 import org.jenkinsci.plugins.ghprb.GhprbPullRequestMerge;
 import org.jenkinsci.plugins.ghprb.GhprbTrigger;
 import org.jenkinsci.plugins.ghprb.upstream.GhprbUpstreamStatus;
 
-import java.util.ArrayList;
 
 @Extension(optional = true)
 public class GhprbContextExtensionPoint extends ContextExtensionPoint {
@@ -40,8 +38,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 null,
                 null,
-                context.extensionContext.extensions,
-                null
+                context.extensionContext.extensions
         );
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
@@ -83,22 +83,22 @@ public abstract class GhprbITBaseTestCase {
         GhprbTestUtil.mockCommitList(ghPullRequest);
         
 
-        GhprbRepository repo = Mockito.spy(new GhprbRepository("user", "dropwizard", trigger));
+        GhprbRepository repo = Mockito.spy(new GhprbRepository("user/dropwizard", trigger));
         Mockito.doReturn(ghRepository).when(repo).getGitHubRepo();
         Mockito.doNothing().when(repo).addComment(Mockito.anyInt(), Mockito.anyString(), any(AbstractBuild.class), any(TaskListener.class));
         
+        Mockito.doReturn(repo).when(trigger).getRepository();
 
         builds = new GhprbBuilds(trigger, repo);
 
         // Creating spy on ghprb, configuring repo
         given(helper.getGitHub()).willReturn(ghprbGitHub);
-        given(helper.getRepository()).willReturn(repo);
         given(helper.getTrigger()).willReturn(trigger);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getBuilds()).willReturn(builds);
         
 
-        Mockito.doCallRealMethod().when(helper).run();
+        Mockito.doCallRealMethod().when(trigger).run();
 
 
         // Configuring and adding Ghprb trigger

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -110,6 +110,7 @@ public class GhprbPullRequestMergeTest {
         triggerValues.put("triggerPhrase", triggerPhrase);
         
         GhprbTrigger trigger = GhprbTestUtil.getTrigger(triggerValues);
+        Mockito.doReturn(repo).when(trigger).getRepository();
 
         ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
         
@@ -163,7 +164,6 @@ public class GhprbPullRequestMergeTest {
         helper = spy(new Ghprb(trigger));
         given(trigger.getPullRequests()).willReturn(pulls);
         trigger.setHelper(helper);
-        given(helper.getRepository()).willReturn(repo);
         given(helper.isBotUser(any(GHUser.class))).willReturn(false);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -119,8 +119,8 @@ public class GhprbPullRequestMergeTest {
         jobs.put("project", pulls);
 
         Mockito.doReturn(project).when(trigger).getActualProject();
-        Mockito.doReturn(pulls).when(trigger).getPullRequests();
         Mockito.doReturn(repo).when(trigger).getRepository();
+        repo.addPullRequests(pulls);
         Mockito.doReturn(pr).when(repo).getPullRequest(pullId);
         
         
@@ -162,7 +162,6 @@ public class GhprbPullRequestMergeTest {
         jobsField.set(descriptor, jobs);
 
         helper = spy(new Ghprb(trigger));
-        given(trigger.getPullRequests()).willReturn(pulls);
         trigger.setHelper(helper);
         given(helper.isBotUser(any(GHUser.class))).willReturn(false);
     }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -24,6 +24,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import com.coravy.hudson.plugins.github.GithubProjectProperty;
+
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -101,9 +103,11 @@ public class GhprbRepositoryTest {
     @Before
     public void setUp() throws Exception {
         AbstractProject<?, ?> project = jenkinsRule.createFreeStyleProject("GhprbRepoTest");
+        project.addProperty(new GithubProjectProperty("https://github.com/" + TEST_REPO_NAME));
         trigger = GhprbTestUtil.getTrigger(null);
         trigger.start(project, true);
         trigger.setHelper(helper);
+        
         gt = trigger.getGitHub();
         
         pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>();
@@ -501,7 +505,7 @@ public class GhprbRepositoryTest {
 
         // WHEN
         ghprbRepository.check();
-        verify(helper).isProjectDisabled();
+        verify(trigger).isActive();
 
         // THEN
         verifyGetGithub(2, 1);
@@ -520,7 +524,7 @@ public class GhprbRepositoryTest {
         ghprbRepository.check();
 
         // THEN
-        verify(trigger, times(2)).getGitHub();
+        verify(trigger, times(1)).getGitHub();
         verify(gt, only()).getRateLimit();
         verifyZeroInteractions(ghRepository);
         verifyZeroInteractions(gitHub);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -387,8 +387,6 @@ public class GhprbTestUtil {
         GitHub github = Mockito.mock(GitHub.class);
         given(github.getRateLimit()).willReturn(limit);
 
-        ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
-        Mockito.doReturn(pulls).when(trigger).getPullRequests();
         Mockito.doReturn(github).when(trigger).getGitHub();
         
         return trigger;


### PR DESCRIPTION
Moving the current states of any open PRs to the job config , or keeping it in the plugin config, isn't a very good option.   Several issues have been created based on the trigger saving those configs many times, and those same files are sometimes kept historically causing a lot of noise.  

This PR moves that status into the build directory, which can then be filtered by change tracking systems.  This also lays the groundwork for multiple GitHub repositories to be handles by one job trigger.