### PR TITLE
All getters should use get, and not is

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -195,7 +195,7 @@ public class GhprbBuilds {
 
         commentOnBuildResult(build, listener, state, c);
         // close failed pull request automatically
-        if (state == GHCommitState.FAILURE && trigger.isAutoCloseFailedPullRequests()) {
+        if (state == GHCommitState.FAILURE && trigger.getAutoCloseFailedPullRequests()) {
             closeFailedRequest(listener, c);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -57,19 +57,19 @@ public class GhprbPullRequestMerge extends Recorder {
         return mergeComment;
     }
 
-    public boolean isOnlyAdminsMerge() {
+    public boolean getOnlyAdminsMerge() {
         return onlyAdminsMerge == null ? false : onlyAdminsMerge;
     }
 
-    public boolean isDisallowOwnCode() {
+    public boolean getDisallowOwnCode() {
         return disallowOwnCode == null ? false : disallowOwnCode;
     }
 
-    public boolean isFailOnNonMerge() {
+    public boolean getFailOnNonMerge() {
         return failOnNonMerge == null ? false : failOnNonMerge;
     }
 
-    public boolean isDeleteOnMerge() {
+    public boolean getDeleteOnMerge() {
         return deleteOnMerge == null ? false : deleteOnMerge;
     }
 
@@ -77,10 +77,10 @@ public class GhprbPullRequestMerge extends Recorder {
         return BuildStepMonitor.BUILD;
     }
 
-    private GhprbTrigger trigger;
-    private Ghprb helper;
-    private GhprbCause cause;
-    private GHPullRequest pr;
+    private transient GhprbTrigger trigger;
+    private transient Ghprb helper;
+    private transient GhprbCause cause;
+    private transient GHPullRequest pr;
 
     @VisibleForTesting
     void setHelper(Ghprb helper) {
@@ -134,7 +134,7 @@ public class GhprbPullRequestMerge extends Recorder {
         }
 
         // If there is no intention to merge there is no point checking
-        if (intendToMerge && isOnlyAdminsMerge() && (triggerSender == null || !helper.isAdmin(triggerSender))) {
+        if (intendToMerge && getOnlyAdminsMerge() && (triggerSender == null || !helper.isAdmin(triggerSender))) {
             canMerge = false;
             logger.println("Only admins can merge this pull request, " + (triggerSender != null ? triggerSender.getLogin() + " is not an admin" : " and build was triggered via automation") + ".");
             if (triggerSender != null) {
@@ -143,7 +143,7 @@ public class GhprbPullRequestMerge extends Recorder {
         }
 
         // If there is no intention to merge there is no point checking
-        if (intendToMerge && isDisallowOwnCode() && (triggerSender == null || isOwnCode(pr, triggerSender))) {
+        if (intendToMerge && getDisallowOwnCode() && (triggerSender == null || isOwnCode(pr, triggerSender))) {
             canMerge = false;
             if (triggerSender != null) {
                 logger.println("The commentor is also one of the contributors.");
@@ -181,7 +181,7 @@ public class GhprbPullRequestMerge extends Recorder {
         }
 
         // We should only fail the build if there is an intent to merge
-        if (intendToMerge && !canMerge && isFailOnNonMerge()) {
+        if (intendToMerge && !canMerge && getFailOnNonMerge()) {
             listener.finished(Result.FAILURE);
         } else {
             listener.finished(Result.SUCCESS);
@@ -190,7 +190,7 @@ public class GhprbPullRequestMerge extends Recorder {
     }
 
     private void deleteBranch(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener) {
-        if (!isDeleteOnMerge()) {
+        if (!getDeleteOnMerge()) {
             return;
         }
         String branchName = pr.getHead().getRef();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -51,10 +51,10 @@ public class GhprbRepository implements Saveable{
     private static final transient EnumSet<GHEvent> HOOK_EVENTS = EnumSet.of(GHEvent.ISSUE_COMMENT, GHEvent.PULL_REQUEST);
 
     private final String reponame;
+    private final Map<Integer, GhprbPullRequest> pullRequests;
 
     private transient GHRepository ghRepository;
     private transient GhprbTrigger trigger;
-    private final Map<Integer, GhprbPullRequest> pullRequests;
 
     public GhprbRepository(String reponame, GhprbTrigger trigger) {
         this.pullRequests = new ConcurrentHashMap<Integer, GhprbPullRequest>();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -80,6 +80,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private Boolean displayBuildErrorsOnDownstreamBuilds;
     private List<GhprbBranch> whiteListTargetBranches;
     private String gitHubAuthId;
+    private String triggerPhrase;
     
 
     private transient Ghprb helper;
@@ -348,6 +349,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return text.replace("\n", "\\n").replace("\r", "\\r").replace("\"", "\\\"");
     }
     
+    public String getGitHubAuthId() {
+        return gitHubAuthId == null ? "" : gitHubAuthId;
+    }
+    
     public GhprbGitHubAuth getGitHubApiAuth() {
         if (gitHubAuthId == null) {
             for (GhprbGitHubAuth auth: getDescriptor().getGithubAuth()){
@@ -488,7 +493,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return permitAll != null && permitAll;
     }
 
-    public Boolean isAutoCloseFailedPullRequests() {
+    public Boolean getAutoCloseFailedPullRequests() {
         if (autoCloseFailedPullRequests == null) {
             Boolean autoClose = getDescriptor().getAutoCloseFailedPullRequests();
             return (autoClose != null && autoClose);
@@ -496,7 +501,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return autoCloseFailedPullRequests;
     }
 
-    public Boolean isDisplayBuildErrorsOnDownstreamBuilds() {
+    public Boolean getDisplayBuildErrorsOnDownstreamBuilds() {
         if (displayBuildErrorsOnDownstreamBuilds == null) {
             Boolean displayErrors = getDescriptor().getDisplayBuildErrorsOnDownstreamBuilds();
             return (displayErrors != null && displayErrors);
@@ -806,6 +811,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         public GHCommitState getUnstableAs() {
             return unstableAs;
+        }
+        
+        public Integer getConfigVersion() {
+            return configVersion;
         }
 
         public boolean isUseComments() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTriggerBackwardsCompatible.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTriggerBackwardsCompatible.java
@@ -26,7 +26,6 @@ public abstract class GhprbTriggerBackwardsCompatible extends Trigger<AbstractPr
     protected final int latestVersion = 3;
     
 
-    protected String triggerPhrase;
     protected Integer configVersion;
 
     public GhprbTriggerBackwardsCompatible(String cron) throws ANTLRException {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbPublishJenkinsUrl.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbPublishJenkinsUrl.java
@@ -49,7 +49,7 @@ public class GhprbPublishJenkinsUrl extends GhprbExtension implements GhprbComme
             return "";
         }
         JobConfiguration jobConfiguration = JobConfiguration.builder()
-                .printStackTrace(trigger.isDisplayBuildErrorsOnDownstreamBuilds()).build();
+                .printStackTrace(trigger.getDisplayBuildErrorsOnDownstreamBuilds()).build();
 
         GhprbBuildManager buildManager = GhprbBuildManagerFactoryUtil.getBuildManager(build, jobConfiguration);
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -172,7 +172,7 @@ public void onBuildTriggered(AbstractProject<?, ?> project, String commitSha, bo
         if (trigger == null) {
             listener.getLogger().println("Unable to get pull request builder trigger!!");
         } else {
-            JobConfiguration jobConfiguration = JobConfiguration.builder().printStackTrace(trigger.isDisplayBuildErrorsOnDownstreamBuilds()).build();
+            JobConfiguration jobConfiguration = JobConfiguration.builder().printStackTrace(trigger.getDisplayBuildErrorsOnDownstreamBuilds()).build();
 
             GhprbBuildManager buildManager = GhprbBuildManagerFactoryUtil.getBuildManager(build, jobConfiguration);
             sb.append(buildManager.getOneLineTestResults());

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GeneralTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GeneralTest.java
@@ -1,0 +1,66 @@
+package org.jenkinsci.plugins.ghprb;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+
+import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildLog;
+import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage;
+import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus;
+import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbCommentFile;
+import org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GeneralTest {
+    
+    private void checkClassForGetters(Class<?> clazz) {
+        List<String> errors = GhprbTestUtil.checkClassForGetters(clazz);
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    public void checkTriggerForGetters() {
+        checkClassForGetters(GhprbTrigger.class);
+    }
+
+    @Test
+    public void checkTriggerDescriptorForGetters() {
+        checkClassForGetters(GhprbTrigger.DescriptorImpl.class);
+    }
+
+    @Test
+    public void checkPullRequestMergeForGetters() {
+        checkClassForGetters(GhprbPullRequestMerge.class);
+    }
+    
+    @Test
+    public void checkBuildLogForGetters() {
+        checkClassForGetters(GhprbBuildLog.class);
+    }
+
+
+    @Test
+    public void checkBuildResultMessageForGetters() {
+        checkClassForGetters(GhprbBuildResultMessage.class);
+    }
+
+    @Test
+    public void checkBuildStatusForGetters() {
+        checkClassForGetters(GhprbBuildStatus.class);
+    }
+
+    @Test
+    public void checkCommentFileForGetters() {
+        checkClassForGetters(GhprbCommentFile.class);
+    }
+
+
+    @Test
+    public void checkSimpleStatusForGetters() {
+        checkClassForGetters(GhprbSimpleStatus.class);
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
@@ -16,7 +16,6 @@ import java.util.regex.Pattern;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHPullRequest;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -123,7 +122,7 @@ public class GhprbTriggerTest {
 
             }
         }
-
     }
+    
 
 }


### PR DESCRIPTION
Fixes #243 
For any web facing classes the getters need to use get and not is or they won't be picked up when accessing the configuration page.