### PR TITLE
update 'githubPullRequest' to 'pullRequest' in Job DSL section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ job('upstreamJob') {
     }
 
     triggers {
-        githubPullRequest {
+        pullRequest {
             admin('user_1')
             admins(['user_2', 'user_3'])
             userWhitelist('you@you.com')


### PR DESCRIPTION
It appears `githubPullRequest` should actually be `pullRequest` according to [this source](https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.triggers.TriggerContext.pullRequest).

When using `githubPullRequest` as exemplified in the README, I had been seeing the following when attempting to run:
```
javaposse.jobdsl.dsl.DslScriptException: (script, line 39) No signature of method: 
javaposse.jobdsl.dsl.helpers.triggers.TriggerContext.githubPullRequest() is applicable 
for argument types: (script$_run_closure1_closure5_closure12) values: 
[script$_run_closure1_closure5_closure12@411c321a]
```