### PR TITLE
Fix NPE when last build has been deleted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -295,7 +295,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         BuildData buildData = null;
         if (!(job instanceof MatrixProject) && !StringUtils.isEmpty(lastBuildId)) {
             AbstractBuild<?, ?> lastBuild = job.getBuild(lastBuildId);
-            buildData = lastBuild.getAction(BuildData.class);
+            if (lastBuild != null) {
+                buildData = lastBuild.getAction(BuildData.class);
+            }
         }
 
         try {


### PR DESCRIPTION
Should fix https://github.com/janinko/ghprb/issues/389

Even though last build ID is not null, the actual build may have been removed from jenkins, most likely if the job is configured to keep only that last N builds.

This will ensure the build is not null before getting the build data.