### PR TITLE
If user is accepted after PR was opened, we should actually set as accepted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -217,7 +217,7 @@ public class GhprbPullRequest {
                 // the author of the PR could have been whitelisted since its creation
                 if (!accepted && helper.isWhitelisted(pr.getUser())) {
                     logger.log(Level.INFO, "Pull request #{0}'s author has been whitelisted", new Object[] { id });
-                    setAccepted(false);
+                    setAccepted(true);
                 }
 
                 int commentsChecked = checkComments(pr, lastUpdateTime);


### PR DESCRIPTION
@DavidTanner I saw this just looking at the code.  Should this not be setAccepted(true) here?  Otherwise there is no state change in the if at all.