### PR TITLE
Add logging properties for surefire tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,14 @@
                         <version>2.16</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.config.file</name>
+                            <value>${project.build.testOutputDirectory}/surefire-logging.properties</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -149,6 +157,12 @@
                     <includes>
                         <include>**/*IT.java</include>
                     </includes>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.config.file</name>
+                            <value>${project.build.testOutputDirectory}/surefire-logging.properties</value>
+                        </property>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.4.1</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/resources/surefire-logging.properties
+++ b/src/test/resources/surefire-logging.properties
@@ -1,0 +1,11 @@
+# Default handlers for all loggers
+handlers=java.util.logging.ConsoleHandler
+
+# Logging levels for handlers
+java.util.logging.ConsoleHandler.level=ALL
+
+# Default logging level for all loggers
+.level=WARNING
+
+# Package logging levels
+org.jenkinsci.plugins.ghprb.level=WARNING


### PR DESCRIPTION
This addresses Issue #285 

There's still a bunch of noise in there but at least all the warnings are now coming from code that is part of the project and they run correctly with JDK 1.8