### PR TITLE
Adding functionality to not post commit status for children jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -36,10 +36,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStatus, GhprbGlobalExtension, GhprbProjectExtension, GhprbGlobalDefault {
 
+    private static final Logger logger = Logger.getLogger(GhprbSimpleStatus.class.getName());
+
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
     private final String commitStatusContext;
-    private final boolean showMatrixStatus;
+    private final Boolean showMatrixStatus;
     private final String triggeredStatus;
     private final String startedStatus;
     private final String statusUrl;
@@ -74,7 +76,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
     public String getStatusUrl() {
         return statusUrl == null ? "" : statusUrl;
     }
-    public boolean getShowMatrixStatus(){return showMatrixStatus;}
+    public boolean getShowMatrixStatus(){return showMatrixStatus == null ? false: showMatrixStatus;}
 
     public String getCommitStatusContext() {
         return commitStatusContext == null ? "" : commitStatusContext;
@@ -173,7 +175,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
             sb.append(Ghprb.replaceMacros(build, listener, startedStatus));
         }
 
-        if((showMatrixStatus && build.getProject() instanceof MatrixProject)){
+        if(showMatrixStatus && !(build.getProject() instanceof MatrixProject)){
             return;
         }
 
@@ -216,7 +218,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
             }
         }
 
-        if((showMatrixStatus && build.getProject() instanceof MatrixProject)){
+        if(showMatrixStatus && !(build.getProject() instanceof MatrixProject)){
             return;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -177,9 +177,12 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
             sb.append(Ghprb.replaceMacros(build, listener, startedStatus));
         }
 
-        if(!showMatrixStatus || (showMatrixStatus && build.getProject() instanceof MatrixProject)){
-            createCommitStatus(build, listener, sb.toString(), repo, GHCommitState.PENDING);
+        if((showMatrixStatus && build.getProject() instanceof MatrixProject)){
+            return;
         }
+
+        createCommitStatus(build, listener, sb.toString(), repo, GHCommitState.PENDING);
+
     }
 
     public void onBuildComplete(AbstractBuild<?, ?> build,
@@ -218,9 +221,10 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
             }
         }
 
-        if(!showMatrixStatus || (showMatrixStatus && build.getProject() instanceof MatrixProject)){
-            createCommitStatus(build, listener, sb.toString(), repo, state);
+        if((showMatrixStatus && build.getProject() instanceof MatrixProject)){
+            return;
         }
+        createCommitStatus(build, listener, sb.toString(), repo, state);
     }
 
     private void createCommitStatus(AbstractBuild<?, ?> build,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -34,9 +34,7 @@ import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStatus, GhprbGlobalExtension,
-                               GhprbProjectExtension, GhprbGlobalDefault {
-    private static final Logger logger = Logger.getLogger(GhprbSimpleStatus.class.getName());
+public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStatus, GhprbGlobalExtension, GhprbProjectExtension, GhprbGlobalDefault {
 
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
@@ -56,10 +54,8 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
         this(true,commitStatusContext, null, null, null, false, new ArrayList<GhprbBuildResultMessage>(0));
     }
 
-
     @DataBoundConstructor
-    public GhprbSimpleStatus(
-                             Boolean showMatrixStatus,
+    public GhprbSimpleStatus(Boolean showMatrixStatus,
                              String commitStatusContext,
                              String statusUrl,
                              String triggeredStatus,
@@ -182,7 +178,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
         }
 
         createCommitStatus(build, listener, sb.toString(), repo, GHCommitState.PENDING);
-
     }
 
     public void onBuildComplete(AbstractBuild<?, ?> build,
@@ -224,6 +219,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
         if((showMatrixStatus && build.getProject() instanceof MatrixProject)){
             return;
         }
+
         createCommitStatus(build, listener, sb.toString(), repo, state);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -62,6 +62,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
         executeInContext(closure, context);
 
         return new GhprbUpstreamStatus(
+                false,
                 context.context,
                 context.statusUrl,
                 context.triggeredStatus,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbExtensionContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbExtensionContext.java
@@ -19,6 +19,7 @@ class GhprbExtensionContext implements Context {
         ContextExtensionPoint.executeInContext(closure, context);
 
         extensions.add(new GhprbSimpleStatus(
+                false,
                 context.context,
                 context.statusUrl,
                 context.triggeredStatus,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus.java
@@ -21,7 +21,7 @@ import java.util.Map.Entry;
  */
 
 public class GhprbUpstreamStatus extends BuildWrapper {
-
+    private final Boolean showMatrixStatus;
     private final String commitStatusContext;
     private final String triggeredStatus;
     private final String startedStatus;
@@ -32,6 +32,7 @@ public class GhprbUpstreamStatus extends BuildWrapper {
     // sets the context and message as env vars so that they are available in the Listener class
     @Override
     public void makeBuildVariables(@SuppressWarnings("rawtypes") AbstractBuild build, Map<String,String> variables){
+        variables.put("ghprbShowMatrixStatus",Boolean.toString(getShowMatrixStatus()));
         variables.put("ghprbUpstreamStatus", "true");
         variables.put("ghprbCommitStatusContext", getCommitStatusContext());
         variables.put("ghprbTriggeredStatus", getTriggeredStatus());
@@ -75,6 +76,7 @@ public class GhprbUpstreamStatus extends BuildWrapper {
 
     @DataBoundConstructor
     public GhprbUpstreamStatus(
+            Boolean showMatrixStatus,
             String commitStatusContext, 
             String statusUrl, 
             String triggeredStatus, 
@@ -82,6 +84,7 @@ public class GhprbUpstreamStatus extends BuildWrapper {
             Boolean addTestResults,
             List<GhprbBuildResultMessage> completedStatus
             ) {
+        this.showMatrixStatus = showMatrixStatus;
         this.statusUrl = statusUrl;
         this.commitStatusContext = commitStatusContext == null ? "" : commitStatusContext;
         this.triggeredStatus = triggeredStatus;
@@ -110,6 +113,8 @@ public class GhprbUpstreamStatus extends BuildWrapper {
     public Boolean getAddTestResults() {
         return addTestResults == null ? false : addTestResults;
     }
+
+    public Boolean getShowMatrixStatus(){return showMatrixStatus == null ? false : showMatrixStatus;}
 
 
     public List<GhprbBuildResultMessage> getCompletedStatus() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
@@ -67,7 +67,7 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
         
         Boolean addTestResults = new Boolean(envVars.get("ghprbStartedStatus"));
 
-        statusUpdater = new GhprbSimpleStatus(envVars.get("ghprbCommitStatusContext"), envVars.get("ghprbStatusUrl"), envVars.get("ghprbTriggeredStatus"), envVars.get("ghprbStartedStatus"), addTestResults, statusMessages);
+        statusUpdater = new GhprbSimpleStatus(Boolean.valueOf(envVars.get("ghprbShowMatrixStatus")),envVars.get("ghprbCommitStatusContext"), envVars.get("ghprbStatusUrl"), envVars.get("ghprbTriggeredStatus"), envVars.get("ghprbStartedStatus"), addTestResults, statusMessages);
 
         String credentialsId = envVars.get("ghprbCredentialsId");
         String repoName = envVars.get("ghprbGhRepository");
@@ -89,7 +89,6 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
     public Environment setUpEnvironment(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener) {
         if (updateEnvironmentVars(build, listener)) {
             logger.log(Level.FINE, "Job: " + build.getFullDisplayName() + " Attempting to send GitHub commit status");
-            
             try {
                 statusUpdater.onEnvironmentSetup(build, listener, repo);
             } catch (GhprbCommitStatusException e) {
@@ -119,7 +118,6 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
         if (!updateEnvironmentVars(build, listener)) {
             return;
         }
-        
         try {
             statusUpdater.onBuildComplete(build, listener, repo);
         } catch (GhprbCommitStatusException e) {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
@@ -1,4 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="Only post commit status of parent matrix job" field="showMatrixStatus">
+    <f:checkbox default = "${descriptor.getShowMatrixStatusDefault(instance)}" placeholder = "${descriptor.getShowMatrixStatusDefault(instance)}"/>
+  </f:entry>
   <f:entry title="${%Commit Status Context}" field="commitStatusContext">
     <f:textbox default="${descriptor.getCommitStatusContextDefault(instance)}"  placeholder="${descriptor.getCommitStatusContextDefault(instance)}"/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/help-showMatrixStatus.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/help-showMatrixStatus.html
@@ -1,0 +1,3 @@
+<div>
+    Does not post commit statuses for the children jobs for a Matrix job
+</div>


### PR DESCRIPTION
This pull request contains the solution for  [https://github.com/jenkinsci/ghprb-plugin/issues/301](https://github.com/jenkinsci/ghprb-plugin/issues/301).

It adds the ability to allow the user to not post commit statuses for the child job of a parent matrix job. If the checkbox is for this function is not pressed, it will follow its default behaviour.

I've added a checkbox in the config.jelly file that saves the value in "showMatrixStatus". The GhprbSimpleStatus class will read the value of the field. If the value is false it will create a commit status and proceed as normal (!showMatrixStatus). If the value is true, then will check if the project is a matrix project. Since the children jobs are not Matrix projects, we can avoid posting commit statuses for them by checking both the value of the box and if it is an instance of a matrix  project (showMatrixStatus && build.getProject() instanceof MatrixProject)

