### PR TITLE
If the trigger is not set up properly, catch Exception

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -186,8 +186,13 @@ public class GhprbRootAction implements UnprotectedRootAction {
                     logger.log(Level.WARNING, "Warning, trigger unexpectedly null for project " + project.getFullName());
                     continue;
                 }
-                if (trigger.matchSignature(body, signature)) {
-                    triggers.add(trigger);
+                try {
+                    if (trigger.matchSignature(body, signature)) {
+                        triggers.add(trigger);
+                    }
+                }
+                catch (Exception e) {
+                    logger.log(Level.SEVERE, "Failed to match signature for trigger on project: " + trigger.getProjectName(), e);
                 }
             }
         }


### PR DESCRIPTION
If the trigger isn't set up properly (for instance, a missing github URL), catch the Exception so that the failure doesn't block other triggers