### PR TITLE
Handle webhooks in separate threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.71</version>
+            <version>1.72.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -9,6 +9,7 @@ import hudson.security.csrf.CrumbExclusion;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.github.GHEventPayload.IssueComment;
 import org.kohsuke.github.GHEventPayload.PullRequest;
 import org.kohsuke.github.GHIssueState;
@@ -21,8 +22,10 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -38,6 +41,8 @@ import javax.servlet.http.HttpServletRequest;
 public class GhprbRootAction implements UnprotectedRootAction {
     static final String URL = "ghprbhook";
     private static final Logger logger = Logger.getLogger(GhprbRootAction.class.getName());
+    
+    private Set<StartTrigger> triggerThreads;
 
     public String getIconFileName() {
         return null;
@@ -50,11 +55,20 @@ public class GhprbRootAction implements UnprotectedRootAction {
     public String getUrlName() {
         return URL;
     }
+    
+    public int getThreadCount() {
+        return triggerThreads == null ? 0 : triggerThreads.size();
+    }
+    
+    public GhprbRootAction() {
+        triggerThreads = Collections.newSetFromMap(new WeakHashMap<StartTrigger, Boolean>());
+    }
 
-    public void doIndex(StaplerRequest req, StaplerResponse resp) {
-        String event = req.getHeader("X-GitHub-Event");
-        String signature = req.getHeader("X-Hub-Signature");
-        String type = req.getContentType();
+    public void doIndex(StaplerRequest req,
+                        StaplerResponse resp) {
+        final String event = req.getHeader("X-GitHub-Event");
+        final String signature = req.getHeader("X-Hub-Signature");
+        final String type = req.getContentType();
         String payload = null;
         String body = null;
 
@@ -69,7 +83,9 @@ public class GhprbRootAction implements UnprotectedRootAction {
         } else if (type.toLowerCase().startsWith("application/x-www-form-urlencoded")) {
             body = extractRequestBody(req);
             if (body == null || body.length() <= 8) {
-                logger.log(Level.SEVERE, "Request doesn't contain payload. " + "You're sending url encoded request, so you should pass github payload through 'payload' request parameter");
+                logger.log(Level.SEVERE,
+                           "Request doesn't contain payload. "
+                                         + "You're sending url encoded request, so you should pass github payload through 'payload' request parameter");
                 resp.setStatus(StaplerResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -84,79 +100,173 @@ public class GhprbRootAction implements UnprotectedRootAction {
         }
 
         if (payload == null) {
-            logger.log(Level.SEVERE, "Payload is null, maybe content type ''{0}'' is not supported by this plugin. " + "Please use 'application/json' or 'application/x-www-form-urlencoded'",
-                    new Object[] { type });
+            logger.log(Level.SEVERE,
+                       "Payload is null, maybe content type ''{0}'' is not supported by this plugin. "
+                                     + "Please use 'application/json' or 'application/x-www-form-urlencoded'",
+                       new Object[] { type });
             resp.setStatus(StaplerResponse.SC_UNSUPPORTED_MEDIA_TYPE);
             return;
         }
 
         logger.log(Level.FINE, "Got payload event: {0}", event);
-        
+        final String threadBody = body;
+        final String threadPayload = payload;
+        handleAction(event, signature, threadPayload, threadBody);
+    }
+
+    private void handleAction(String event,
+                              String signature,
+                              String payload,
+                              String body) {
+
         // Not sure if this is needed, but it may be to get info about old builds.
         Authentication old = SecurityContextHolder.getContext().getAuthentication();
         SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
 
+        IssueComment comment = null;
+        PullRequest pr = null;
+        String repoName = null;
+
         try {
             GitHub gh = GitHub.connectAnonymously();
 
-            if ("issue_comment".equals(event)) {
-                IssueComment issueComment = getIssueComment(payload, gh);
-                GHIssueState state = issueComment.getIssue().getState();
+            if (StringUtils.equalsIgnoreCase("issue_comment", event)) {
+
+                comment = getIssueComment(payload, gh);
+                GHIssueState state = comment.getIssue().getState();
+
                 if (state == GHIssueState.CLOSED) {
                     logger.log(Level.INFO, "Skip comment on closed PR");
                     return;
                 }
-                
-                if (!issueComment.getIssue().isPullRequest()) {
+
+                if (!comment.getIssue().isPullRequest()) {
                     logger.log(Level.INFO, "Skip comment on Issue");
                     return;
                 }
 
-                String repoName = issueComment.getRepository().getFullName();
+                repoName = comment.getRepository().getFullName();
 
-                logger.log(Level.INFO, "Checking issue comment ''{0}'' for repo {1}", new Object[] { issueComment.getComment().getBody(), repoName });
+                logger.log(Level.INFO,
+                           "Checking issue comment ''{0}'' for repo {1}",
+                           new Object[] { comment.getComment().getBody(), repoName });
 
-                for (GhprbTrigger trigger : getTriggers(repoName, body, signature)) {
-                    try {
-                        IssueComment authedComment = getIssueComment(payload, trigger.getGitHub());
-                        trigger.handleComment(authedComment);
-                    } catch (Exception e) {
-                        logger.log(Level.SEVERE, "Unable to process web hook for: " + trigger.getProjectName(), e);
-                    }
-                }
+            } else if (StringUtils.equalsIgnoreCase("pull_request", event)) {
 
-            } else if ("pull_request".equals(event)) {
-                PullRequest pr = getPullRequest(payload, gh);
-                String repoName = pr.getRepository().getFullName();
+                pr = getPullRequest(payload, gh);
+                repoName = pr.getRepository().getFullName();
 
                 logger.log(Level.INFO, "Checking PR #{1} for {0}", new Object[] { repoName, pr.getNumber() });
 
-                for (GhprbTrigger trigger : getTriggers(repoName, body, signature)) {
-                    try {
-                        PullRequest authedPr = getPullRequest(payload, trigger.getGitHub());
-                        trigger.handlePR(authedPr);
-                    } catch (Exception e) {
-                        logger.log(Level.SEVERE, "Unable to process web hook for: " + trigger.getProjectName(), e);
-                    }
-                }
             } else {
-                logger.log(Level.WARNING, "Request not known");
+                logger.log(Level.WARNING, "Request not known for event: {0}", new Object[] { event });
+                return;
             }
+
+            Set<GhprbTrigger> triggers = getTriggers(repoName, body, signature);
+
+            handleEvent(triggers, payload, pr, comment);
 
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Unable to connect to GitHub anonymously", e);
         } finally {
             SecurityContextHolder.getContext().setAuthentication(old);
         }
-
     }
 
-    private PullRequest getPullRequest(String payload, GitHub gh) throws IOException {
+    private class StartTrigger implements Runnable {
+        GhprbTrigger trigger;
+        PullRequest pr;
+        IssueComment comment;
+
+        @Override
+        public void run() {
+            try {
+                if (pr != null) {
+                    triggerPr(trigger, pr);
+                }
+
+                if (comment != null) {
+                    triggerComment(trigger, comment);
+                }
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Failed to run thread", e);
+            } finally {
+                triggerThreads.remove(this);
+            }
+        }
+    }
+
+    private void handleEvent(Set<GhprbTrigger> triggers,
+                             String payload,
+                             PullRequest anonPr,
+                             IssueComment anonComment) {
+
+        for (final GhprbTrigger trigger : triggers) {
+            try {
+                final StartTrigger runner = new StartTrigger();
+                runner.trigger = trigger;
+                if (anonPr != null) {
+                    runner.pr = getPullRequest(payload, trigger.getGitHub());
+                }
+                if (anonComment != null) {
+                    runner.comment = getIssueComment(payload, trigger.getGitHub());
+                }
+
+                Thread thread = new Thread(runner);
+                triggerThreads.add(runner);
+                thread.start();
+            } catch (IOException e) {
+                logger.log(Level.SEVERE, "Unable to get authorized version of event", e);
+            }
+        }
+    }
+
+    private void triggerComment(final GhprbTrigger trigger,
+                                final IssueComment comment) {
+        new Thread() {
+            public void run() {
+                try {
+                    trigger.handleComment(comment);
+                } catch (Exception e) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Unable to handle comment for PR# ");
+                    sb.append(comment.getIssue().getId());
+                    sb.append(", repo: ");
+                    sb.append(comment.getRepository().getFullName());
+
+                    logger.log(Level.SEVERE, sb.toString(), e);
+                }
+            }
+        }.start();
+    }
+
+    private void triggerPr(final GhprbTrigger trigger,
+                           final PullRequest pr) {
+        new Thread() {
+            public void run() {
+                try {
+                    trigger.handlePR(pr);
+                } catch (Exception e) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Unable to handle PR# ");
+                    sb.append(pr.getNumber());
+                    sb.append(" for repo: ");
+                    sb.append(pr.getRepository().getFullName());
+                    logger.log(Level.SEVERE, sb.toString(), e);
+                }
+            }
+        }.start();
+    }
+
+    private PullRequest getPullRequest(String payload,
+                                       GitHub gh) throws IOException {
         PullRequest pr = gh.parseEventPayload(new StringReader(payload), PullRequest.class);
         return pr;
     }
 
-    private IssueComment getIssueComment(String payload, GitHub gh) throws IOException {
+    private IssueComment getIssueComment(String payload,
+                                         GitHub gh) throws IOException {
         IssueComment issueComment = gh.parseEventPayload(new StringReader(payload), IssueComment.class);
         return issueComment;
     }
@@ -175,7 +285,9 @@ public class GhprbRootAction implements UnprotectedRootAction {
         return body;
     }
 
-    private Set<GhprbTrigger> getTriggers(String repoName, String body, String signature) {
+    private Set<GhprbTrigger> getTriggers(String repoName,
+                                          String body,
+                                          String signature) {
         Set<GhprbTrigger> triggers = new HashSet<GhprbTrigger>();
 
         Set<AbstractProject<?, ?>> projects = GhprbTrigger.getDscp().getRepoTriggers(repoName);
@@ -183,28 +295,32 @@ public class GhprbRootAction implements UnprotectedRootAction {
             for (AbstractProject<?, ?> project : projects) {
                 GhprbTrigger trigger = Ghprb.extractTrigger(project);
                 if (trigger == null) {
-                    logger.log(Level.WARNING, "Warning, trigger unexpectedly null for project " + project.getFullName());
+                    logger.log(Level.WARNING,
+                               "Warning, trigger unexpectedly null for project " + project.getFullName());
                     continue;
                 }
                 try {
                     if (trigger.matchSignature(body, signature)) {
                         triggers.add(trigger);
                     }
-                }
-                catch (Exception e) {
-                    logger.log(Level.SEVERE, "Failed to match signature for trigger on project: " + trigger.getProjectName(), e);
+                } catch (Exception e) {
+                    logger.log(Level.SEVERE,
+                               "Failed to match signature for trigger on project: " + trigger.getProjectName(),
+                               e);
                 }
             }
         }
         return triggers;
-        
+
     }
 
     @Extension
     public static class GhprbRootActionCrumbExclusion extends CrumbExclusion {
 
         @Override
-        public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain) throws IOException, ServletException {
+        public boolean process(HttpServletRequest req,
+                               HttpServletResponse resp,
+                               FilterChain chain) throws IOException, ServletException {
             String pathInfo = req.getPathInfo();
             if (pathInfo != null && pathInfo.equals(getExclusionPath())) {
                 chain.doFilter(req, resp);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -65,7 +65,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
     
     public GhprbRootAction() {
         triggerThreads = Collections.newSetFromMap(new WeakHashMap<StartTrigger, Boolean>());
-        this.pool = Executors.newFixedThreadPool(10);
+        this.pool = Executors.newCachedThreadPool();
     }
 
     public void doIndex(StaplerRequest req,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,6 +45,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
     private static final Logger logger = Logger.getLogger(GhprbRootAction.class.getName());
     
     private Set<StartTrigger> triggerThreads;
+    private ExecutorService pool;
 
     public String getIconFileName() {
         return null;
@@ -62,6 +65,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
     
     public GhprbRootAction() {
         triggerThreads = Collections.newSetFromMap(new WeakHashMap<StartTrigger, Boolean>());
+        this.pool = Executors.newFixedThreadPool(10);
     }
 
     public void doIndex(StaplerRequest req,
@@ -213,9 +217,8 @@ public class GhprbRootAction implements UnprotectedRootAction {
                     runner.comment = getIssueComment(payload, trigger.getGitHub());
                 }
 
-                Thread thread = new Thread(runner);
                 triggerThreads.add(runner);
-                thread.start();
+                pool.submit(runner);
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "Unable to get authorized version of event", e);
             }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
@@ -149,6 +149,9 @@ public class GhprbRootActionTest {
 
         GhprbRootAction ra = new GhprbRootAction();
         ra.doIndex(req, null);
+        while(ra.getThreadCount() > 0) {
+            Thread.sleep(500);
+        }
         GhprbTestUtil.waitForBuildsToFinish(project);
 
         assertThat(project.getBuilds().toArray().length).isEqualTo(1);


### PR DESCRIPTION
Fixes #307 by handling the trigger execution in separate threads, thus not blocking the http handlers.