### PR TITLE
Add one-line test output option for upstream status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -201,6 +201,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
 
             GhprbBuildManager buildManager = GhprbBuildManagerFactoryUtil.getBuildManager(build, jobConfiguration);
             if (getAddTestResults()) {
+                listener.getLogger().println("Adding one-line test results to commit status...");
                 sb.append(buildManager.getOneLineTestResults());
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
@@ -65,7 +65,7 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
             context = jobName;
         }
         
-        Boolean addTestResults = new Boolean(envVars.get("ghprbStartedStatus"));
+        Boolean addTestResults = new Boolean(envVars.get("ghprbAddTestResults"));
 
         statusUpdater = new GhprbSimpleStatus(envVars.get("ghprbCommitStatusContext"), envVars.get("ghprbStatusUrl"), envVars.get("ghprbTriggeredStatus"), envVars.get("ghprbStartedStatus"), addTestResults, statusMessages);
 

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
@@ -11,6 +11,9 @@
     <f:entry title="${%Commit Status Build Started}" field="startedStatus">
     <f:textbox default="${descriptor.getStartedStatusDefault(instance)}" placeholder="${descriptor.getStartedStatusDefault(instance)}"/>
   </f:entry>
+  <f:entry title="${%Add test result one liner}" field="addTestResults" >
+    <f:checkbox default="${descriptor.getAddTestResultsDefault(instance)}" />
+  </f:entry>
   <f:entry title="${%Commit Status Build Result}" field="completedStatus" >
     <f:repeatableProperty field="completedStatus" default="${descriptor.getCompletedStatusDefault(instance)}" />
   </f:entry>


### PR DESCRIPTION
Fixes janinko/ghprb#390; the 'addTestResults' flag is missing from the GhprbUpstreamStatus ui entirely, and GhprbUpstreamStatusListener is parsing 'ghprbStartedStatus' instead of 'ghprbAddTestResults'.