### PR TITLE
Add option to avoid managing of webhooks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -251,7 +251,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         helper = new Ghprb(this);
         
         if (getUseGitHubHooks()) {
-            this.repository.createHook();
+            if (GhprbTrigger.getDscp().getManageWebhooks()) {
+                this.repository.createHook();
+            }
             DESCRIPTOR.addRepoTrigger(getRepository().getName(), super.job);
         }
     }
@@ -636,6 +638,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private String cron = "H/5 * * * *";
         private Boolean useComments = false;
         private Boolean useDetailedComments = false;
+        private Boolean manageWebhooks = true;
         private GHCommitState unstableAs = GHCommitState.FAILURE;
         private List<GhprbBranch> whiteListTargetBranches;
         private Boolean autoCloseFailedPullRequests = false;
@@ -748,6 +751,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             cron = formData.getString("cron");
             useComments = formData.getBoolean("useComments");
             useDetailedComments = formData.getBoolean("useDetailedComments");
+            manageWebhooks = formData.getBoolean("manageWebhooks");
             unstableAs = GHCommitState.valueOf(formData.getString("unstableAs"));
             autoCloseFailedPullRequests = formData.getBoolean("autoCloseFailedPullRequests");
             displayBuildErrorsOnDownstreamBuilds = formData.getBoolean("displayBuildErrorsOnDownstreamBuilds");
@@ -829,6 +833,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             return useDetailedComments;
         }
 
+        public Boolean getManageWebhooks() {
+            return manageWebhooks;
+        }
 
         public Boolean getAutoCloseFailedPullRequests() {
             return autoCloseFailedPullRequests;
@@ -852,6 +859,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         public boolean isUseDetailedComments() {
             return (useDetailedComments != null && useDetailedComments);
+        }
+        
+        public boolean isManageWebhooks() {
+            return (manageWebhooks != null && manageWebhooks);
         }
 
         public ListBoxModel doFillGitHubAuthIdItems(@QueryParameter("gitHubAuthId") String gitHubAuthId) {
@@ -916,7 +927,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             Set<AbstractProject<?, ?>> projects = repoJobs.get(repo);
             if (projects != null) {
                 for (AbstractProject<?, ?> project : projects) {
-                    logger.log(Level.FINE, "Found project [{0}] for webhook repo [{0}]", new Object[]{project.getFullName(), repo});
+                    logger.log(Level.FINE, "Found project [{0}] for webhook repo [{1}]", new Object[]{project.getFullName(), repo});
                 }
             } else {
                 projects = Collections.newSetFromMap(new WeakHashMap<AbstractProject<?, ?>, Boolean>(0));

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -6,6 +6,9 @@ f.section(title: descriptor.displayName) {
   f.entry(field: "githubAuth", title: _("GitHub Auth")) {
     f.repeatableProperty(field: "githubAuth", default: descriptor.getGithubAuth()) 
   }
+  f.entry(field: "manageWebhooks", title: _("Auto-manage webhooks")) {
+    f.checkbox(default: true) 
+  }  
   f.entry(field: "useComments", title: _("Use comments to report results when updating commit status fails")) {
     f.checkbox() 
   }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -310,6 +310,7 @@ public class GhprbTestUtil {
         jsonObject.put("cron", "0 0 31 2 0");
         jsonObject.put("useComments", "true");
         jsonObject.put("useDetailedComments", "false");
+        jsonObject.put("manageWebhooks", "true");
         jsonObject.put("logExcerptLines", "0");
         jsonObject.put("unstableAs", "FAILURE");
         jsonObject.put("testMode", "true");


### PR DESCRIPTION
Add an option to not have the GHPRB manage its webhooks.  This is preferable in cases where we have a lot of projects pointing at the same repo, or when the ghprb account has no admin access to the repo