### PR TITLE
Compatibility with SECURITY-170

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.596.1</version>
+        <version>2.7</version>
     </parent>
 
     <artifactId>ghprb</artifactId>
@@ -42,6 +42,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <jenkins.version>1.651.2</jenkins.version>
+        <jenkins.test-harness.version>2.7</jenkins.test-harness.version>
     </properties>
 
     <dependencies>
@@ -49,6 +51,11 @@
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
             <version>1.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -68,7 +75,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-agent</artifactId>
-            <version>1.3</version>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -79,7 +86,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -106,6 +112,19 @@
             <version>0.12</version>
             <optional>true</optional>
         </dependency>
+        <!-- Required for HtmlUnit to work -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- otherwise tests get linkage errors from org.jenkinsci.plugins.gitserver.ssh.SshCommandFactoryImpl -->
+            <groupId>org.jenkins-ci.modules</groupId>
+            <artifactId>sshd</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
@@ -123,7 +142,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
@@ -136,7 +154,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
                 <executions>
                     <execution>
                         <goals>
@@ -153,7 +170,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
@@ -165,11 +181,6 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.5.1</version>
-              <configuration>
-                <source>1.6</source>
-                <target>1.6</target>
-              </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbAdditionalParameterEnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbAdditionalParameterEnvironmentContributor.java
@@ -1,0 +1,102 @@
+package org.jenkinsci.plugins.ghprb;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.StringParameterValue;
+import hudson.model.TaskListener;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+@Extension(optional = true)
+public class GhprbAdditionalParameterEnvironmentContributor extends EnvironmentContributor {
+
+    /*
+     * Fail the load of this extension if ParametersAction.getAllParameter() method doesn't exist
+     */
+    static {
+        try {
+            ParametersAction.class.getMethod("getAllParameters");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener)
+            throws IOException, InterruptedException {
+        GhprbCause cause = (GhprbCause) r.getCause(GhprbCause.class);
+        ParametersAction pa = r.getAction(ParametersAction.class);
+        if (cause != null && pa != null) {
+            final String commitSha = cause.isMerged() ? "origin/pr/" + cause.getPullID() + "/merge" : cause.getCommit();
+            putEnvVar(envs, "sha1", commitSha);
+            putEnvVar(envs, "ghprbActualCommit", cause.getCommit());
+
+            try {
+                putEnvVar(envs, "ghprbTriggerAuthor", cause.getTriggerSender().getName());
+            } catch (Exception e) {
+            }
+            try {
+                putEnvVar(envs, "ghprbTriggerAuthorEmail", cause.getTriggerSender().getEmail());
+            } catch (Exception e) {
+            }
+
+            String triggerAuthorLogin = "";
+            try {
+                triggerAuthorLogin = cause.getTriggerSender().getLogin();
+                if (triggerAuthorLogin == null) {
+                    triggerAuthorLogin = "";
+                }
+                putEnvVar(envs, "ghprbTriggerAuthorLogin", triggerAuthorLogin);
+            } catch (Exception e) {
+            }
+
+            putEnvVar(envs, "ghprbActualCommitAuthor", cause.getCommitAuthor().getName());
+            putEnvVar(envs, "ghprbActualCommitAuthorEmail", cause.getCommitAuthor().getEmail());
+            putEnvVar(envs, "ghprbAuthorRepoGitUrl", cause.getAuthorRepoGitUrl());
+
+            putEnvVar(envs, "ghprbTriggerAuthorLoginMention", !triggerAuthorLogin.isEmpty() ? "@"
+                    + triggerAuthorLogin : "");
+            putEnvVar(envs, "ghprbPullId", String.valueOf(cause.getPullID()));
+            putEnvVar(envs, "ghprbTargetBranch", cause.getTargetBranch());
+            putEnvVar(envs, "ghprbSourceBranch", cause.getSourceBranch());
+            putEnvVar(envs, "GIT_BRANCH", cause.getSourceBranch());
+
+            // it's possible the GHUser doesn't have an associated email address
+            putEnvVar(envs, "ghprbPullAuthorEmail", cause.getAuthorEmail());
+            putEnvVar(envs, "ghprbPullAuthorLogin", cause.getPullRequestAuthor().getLogin());
+            putEnvVar(envs, "ghprbPullAuthorLoginMention", "@" + cause.getPullRequestAuthor().getLogin());
+
+            putEnvVar(envs, "ghprbPullDescription", escapeText(String.valueOf(cause.getShortDescription())));
+            putEnvVar(envs, "ghprbPullTitle", cause.getTitle());
+            putEnvVar(envs, "ghprbPullLink", String.valueOf(cause.getUrl()));
+            putEnvVar(envs, "ghprbPullLongDescription", escapeText(String.valueOf(cause.getDescription())));
+
+            putEnvVar(envs, "ghprbCommentBody", escapeText(String.valueOf(cause.getCommentBody())));
+
+            // Cheating for now as the data is not available in the Cause
+            for (ParameterValue pv : pa.getAllParameters()) {
+                if (pv.getName() != null && pv.getValue() != null && pv instanceof StringParameterValue) {
+                    if ("ghprbGhRepository".equals(pv.getName()) || "ghprbCredentialsId".equals(pv.getName()))
+                        envs.put(pv.getName(), pv.getValue().toString());
+                }
+            }
+        }
+    }
+
+    private static String escapeText(String text) {
+        return text.replace("\n", "\\n").replace("\r", "\\r").replace("\"", "\\\"");
+    }
+
+    private static void putEnvVar(@Nonnull EnvVars envs, String name, String value){
+        if (value != null) {
+            envs.put(name, value);
+        } else {
+            envs.put(name, "");
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -296,7 +296,11 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                 ((GhprbBuildStep)ext).onScheduleBuild(super.job, cause);
             }
         }
-        
+
+        /*
+         * setting parameters like this is deprecated now, keeping this code
+         * for old Jenkins version
+         */
         ArrayList<ParameterValue> values = getDefaultParameters();
         final String commitSha = cause.isMerged() ? "origin/pr/" + cause.getPullID() + "/merge" : cause.getCommit();
         values.add(new StringParameterValue("sha1", commitSha));

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 	<f:entry title="Merge comment" field="mergeComment">
 		<f:textarea />

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   	<f:section title="${descriptor.displayName}">
 	  	<f:entry title="Merge comment" field="mergeComment">

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/builds/GhprbCancelBuildsOnUpdate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/builds/GhprbCancelBuildsOnUpdate/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="Override Global setting and don't cancel builds" field="overrideGlobal">
     <f:checkbox />

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildLog/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildLog/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Lines of build log to include in comments}" field="logExcerptLines">
     <f:number default="0"  placeholder="${descriptor.getLogExcerptLinesDefault(instance)}"/>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildResultMessage/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildResultMessage/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Build Result}" field="result">
       <f:select />

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbBuildStatus/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Build Result Message}" field="messages" >
     <f:repeatableProperty field="messages" default="${descriptor.getMessagesDefault(instance)}" placeholder="${descriptor.getMessagesDefault(instance)}"/>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Comment file path}" field="commentFilePath">
       <f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbPublishJenkinsUrl/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbPublishJenkinsUrl/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Published Jenkins URL}" field="publishedURL">
     <f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Commit Status Context}" field="commitStatusContext">
     <f:textbox default="${descriptor.getCommitStatusContextDefault(instance)}"  placeholder="${descriptor.getCommitStatusContextDefault(instance)}"/>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Commit Status Context}" field="commitStatusContext">
     <f:textbox default="${descriptor.getCommitStatusContextDefault(instance)}"  placeholder="${descriptor.getCommitStatusContextDefault(instance)}"/>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -369,10 +369,12 @@ public class GhprbTestUtil {
         given(req.bindJSON(any(Class.class), any(Class.class), any(JSONObject.class))).willCallRealMethod();
         given(req.setBindInterceptpr(any(BindInterceptor.class))).willCallRealMethod();
         given(req.setBindListener(any(BindInterceptor.class))).willCallRealMethod();
+        given(req.setBindInterceptor(any(BindInterceptor.class))).willCallRealMethod();
+        given(req.getBindInterceptor()).willCallRealMethod();
         given(req.getWebApp()).willReturn(webApp);
         
         req.setBindListener(BindInterceptor.NOOP);
-
+        req.setBindInterceptor(BindInterceptor.NOOP);
     }
     
     public static GitSCM provideGitSCM() {

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/factory/GhprbBuildManagerFactoryUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/factory/GhprbBuildManagerFactoryUtilTest.java
@@ -28,7 +28,7 @@ public class GhprbBuildManagerFactoryUtilTest {
     @Test
     public void shouldReturnDefaultManager() throws Exception {
         // GIVEN
-        MatrixProject project = jenkinsRule.createMatrixProject("PRJ");
+        MatrixProject project = jenkinsRule.createProject(MatrixProject.class, "PRJ");
 
         GhprbBuildManager buildManager = GhprbBuildManagerFactoryUtil.getBuildManager(new MatrixBuild(project));
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
@@ -35,7 +35,7 @@ public class GhprbDefaultBuildManagerTest extends GhprbITBaseTestCase {
     @Before
     public void setUp() throws Exception {
         // GhprbTestUtil.mockGithubUserPage();
-        project = jenkinsRule.createMatrixProject("MTXPRJ");
+        project = jenkinsRule.createProject(MatrixProject.class, "MTXPRJ");
        
         Map<String, Object> config = new HashMap<String, Object>(1);
        


### PR DESCRIPTION
This PR fixes the plugin to work with recent Jenkins versions containing the SECURITY-170 fix. I had to switch the parent POM to the new plugin POM in order to compile for 1.651.2.

@reviewbybees