### PR TITLE
Reduce API calls

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
@@ -45,6 +45,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements GhprbBu
             return;
         }
         
+        logger.log(Level.FINER, "New build scheduled for " + project.getName() + " on PR # " + prId + ", checking for queued items to cancel.");
         Queue queue = Jenkins.getInstance().getQueue();
         for (Queue.Item item : queue.getItems(project)) {
             GhprbCause qcause = null;
@@ -58,6 +59,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements GhprbBu
             }
             if (qcause.getPullID() == prId) {
                 try {
+                    logger.log(Level.FINER, "Cancelling queued build of " + project.getName() + " for PR # " + qcause.getPullID() + ", checking for queued items to cancel.");
                     queue.cancel(item);
                 } catch (Exception e) {
                     logger.log(Level.SEVERE, "Unable to cancel queued build", e);
@@ -65,6 +67,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements GhprbBu
             }
         }
 
+        logger.log(Level.FINER, "New build scheduled for " + project.getName() + " on PR # " + prId);
         RunList<?> runs = project.getBuilds();
         for (Run<?, ?> run : runs) {
             if (!run.isBuilding() && !run.hasntStartedYet()) {
@@ -76,6 +79,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements GhprbBu
             }
             if (cause.getPullID() == prId) {
                 try {
+                    logger.log(Level.FINER, "Cancelling running build #" + run.getNumber() + " of " + project.getName() + " for PR # " + cause.getPullID());
                     run.addAction(this);
                     run.getExecutor().interrupt(Result.ABORTED);
                 } catch (Exception e) {

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -142,7 +142,7 @@ public class GhprbPullRequestMergeTest {
         given(build.getResult()).willReturn(Result.SUCCESS);
         given(build.getParent()).willCallRealMethod();
 
-        given(pullRequest.getPullRequest(Mockito.anyBoolean())).willReturn(pr);
+        given(pullRequest.getPullRequest()).willReturn(pr);
 
         given(cause.getPullID()).willReturn(pullId);
         given(cause.isMerged()).willReturn(true);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
@@ -84,7 +84,7 @@ public class GhprbPullRequestTest {
     public void testConstructorWhenAuthorIsWhitelisted() throws IOException {
 
         // WHEN
-        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo, false);
+        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
 
         // THEN
         assertThat(ghprbPullRequest.getId()).isEqualTo(10);
@@ -100,7 +100,7 @@ public class GhprbPullRequestTest {
 
         given(repo.getName()).willReturn(null);
 
-        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo, false);
+        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
 
         // WHEN
         ghprbPullRequest.init(helper, ghprbRepository);
@@ -110,7 +110,7 @@ public class GhprbPullRequestTest {
         verify(pr, times(1)).getBase();
         verify(pr, times(1)).getNumber();
         verify(pr, times(1)).getCreatedAt();
-        verify(pr, times(3)).getUser();
+        verify(pr, times(2)).getUser();
         Mockito.verifyNoMoreInteractions(pr);
 
     }
@@ -122,7 +122,7 @@ public class GhprbPullRequestTest {
         given(repo.getName()).willReturn("name");
         doNothing().when(repo).addComment(eq(10), anyString());
 
-        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo, false);
+        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
 
         // WHEN
         ghprbPullRequest.init(helper, ghprbRepository);
@@ -136,7 +136,7 @@ public class GhprbPullRequestTest {
     public void authorRepoGitUrlShouldBeNullWhenNoRepository() throws Exception {
         // GIVEN
 
-        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo, false);
+        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
 
         // WHEN
         ghprbPullRequest.init(helper, ghprbRepository);
@@ -154,7 +154,7 @@ public class GhprbPullRequestTest {
 
         given(head.getRepository()).willReturn(repository);
 
-        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo, false);
+        GhprbPullRequest ghprbPullRequest = new GhprbPullRequest(pr, helper, repo);
 
         // THEN
         assertThat(ghprbPullRequest.getAuthorRepoGitUrl()).isEqualTo(expectedAuthorRepoGitUrl);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -172,7 +172,7 @@ public class GhprbRepositoryTest {
         ghprbRepository.check();
 
         // THEN
-        verifyGetGithub(3, 3, 1);
+        verifyGetGithub(2, 2, 0);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class GhprbRepositoryTest {
         ghprbRepository.check();
 
         // THEN
-        verifyGetGithub(3, 3, 2);
+        verifyGetGithub(2, 2, 1);
 
         /** GH Repo verifications */
         verify(ghRepository, only()).getPullRequests(OPEN); // Call to Github API
@@ -220,6 +220,8 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
+        verify(ghUser, times(1)).getName();
+        verifyNoMoreInteractions(ghUser);
         verifyZeroInteractions(ghUser);
     }
 
@@ -256,7 +258,7 @@ public class GhprbRepositoryTest {
         ghprbRepository.check();
 
         // THEN
-        verifyGetGithub(3, 3, 2);
+        verifyGetGithub(2, 2, 1);
         verifyNoMoreInteractions(gt);
 
         /** GH PR verifications */
@@ -267,7 +269,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(6)).getUser();
+        verify(ghPullRequest, times(3)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(4)).getBase();
@@ -339,7 +341,7 @@ public class GhprbRepositoryTest {
         ghprbRepository.check(); // PR was updated
 
         // THEN
-        verifyGetGithub(3, 3, 2);
+        verifyGetGithub(2, 2, 1);
         verifyNoMoreInteractions(gt);
 
         /** GH PR verifications */
@@ -350,10 +352,10 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(6)).getUser();
+        verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(9)).getHead();
-        verify(ghPullRequest, times(6)).getBase();
+        verify(ghPullRequest, times(7)).getHead();
+        verify(ghPullRequest, times(4)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(1)).getHtmlUrl();
         verify(ghPullRequest, times(2)).getUpdatedAt();
@@ -381,7 +383,7 @@ public class GhprbRepositoryTest {
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
-        verify(ghUser, times(1)).getName();
+        verify(ghUser, times(3)).getName();
         verifyNoMoreInteractions(ghUser);
     }
 
@@ -430,7 +432,7 @@ public class GhprbRepositoryTest {
         ghprbRepository.check(); // PR was updated
 
         // THEN
-        verifyGetGithub(3, 3, 2);
+        verifyGetGithub(2, 2, 1);
         verifyNoMoreInteractions(gt);
 
         /** GH PR verifications */
@@ -443,10 +445,10 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(7)).getUser();
+        verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(10)).getHead();
-        verify(ghPullRequest, times(6)).getBase();
+        verify(ghPullRequest, times(9)).getHead();
+        verify(ghPullRequest, times(5)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(2)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getCreatedAt();
@@ -474,7 +476,7 @@ public class GhprbRepositoryTest {
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
-        verify(ghUser, times(1)).getName();
+        verify(ghUser, times(2)).getName();
         verifyNoMoreInteractions(ghUser);
 
         verify(builds, times(2)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
@@ -520,7 +522,7 @@ public class GhprbRepositoryTest {
         verify(trigger).isActive();
 
         // THEN
-        verifyGetGithub(3, 3, 2);
+        verifyGetGithub(2, 2, 1);
         verifyNoMoreInteractions(gt);
 
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
@@ -538,8 +540,8 @@ public class GhprbRepositoryTest {
         startTrigger();
 
         // THEN
-        verify(gt, times(2)).getRateLimit();
-        verifyGetGithub(2, 2, 0);
+        verify(gt, times(1)).getRateLimit();
+        verifyGetGithub(1, 1, 0);
         verifyZeroInteractions(ghRepository);
         verifyZeroInteractions(gitHub);
         verifyZeroInteractions(gt);
@@ -596,7 +598,7 @@ public class GhprbRepositoryTest {
         
         doReturn(ghprbRepository).when(trigger).getRepository();
         
-        ghprbPullRequest = new GhprbPullRequest(ghPullRequest, helper, ghprbRepository, false);
+        ghprbPullRequest = new GhprbPullRequest(ghPullRequest, helper, ghprbRepository);
         
         // Reset mocks not to mix init data invocations with tests
         reset(ghPullRequest, ghUser, helper, head, base);


### PR DESCRIPTION
This change reduces the number of API calls made by the ghprb plugin.  .NET CI was hitting rate limits pretty regularly.  There are a few major improvements:
    * When using webhooks, we do not check comments (pull comment data) except when absolutely necessary.   We recieve all the comment info through the hooks, so we only need to check for updated comments when we have a new pull request or when jenkins restarts.
    * Never force a GH pull request update when a comment update comes through.  If a comment update came through, we're using webhooks and will have gotten the updated PR event.
    * initGhRepository isn't necessary when a GhprbRepository is created.  It's not used in the pull request trigger init, and causes an API call.  It can be called on demand as necessary.  This also dramatically improves startup time in Jenkins instances that have a lot of PR triggered jobs

Additional fixes:
    * Fixes a case where the pull request data wasn't saved on a GH hash update (which leads to most PRs restarting testing on any comment if Jenkins restarts)
    * Fixes a potential race condition where multiple triggers would attempt to set up hooks at the same time.

Not all possible improvements are included.  When a new PR or updated PR event is sent to Jenkins, we could pull the GHPullRequest info for affected projects once, instead of for each project which we do today.