### PR TITLE
When downstream jobs are triggered at the same time, the commit statuses overwrite each others

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
@@ -8,7 +8,6 @@ import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.model.listeners.RunListener;
 
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.ghprb.Ghprb;
 import org.jenkinsci.plugins.ghprb.GhprbGitHubAuth;
 import org.jenkinsci.plugins.ghprb.GhprbTrigger;
@@ -35,71 +34,59 @@ import java.util.logging.Logger;
 public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>> {
     private static final Logger logger = Logger.getLogger(GhprbUpstreamStatusListener.class.getName());
     
-    private GhprbSimpleStatus statusUpdater;
-    
     private GHRepository repo;
 
     // Gets all the custom env vars needed to send information to GitHub
-    private boolean updateEnvironmentVars(AbstractBuild<?, ?> build, TaskListener listener){
-
-        
+    private Map<String, String> returnEnvironmentVars(AbstractBuild<?, ?> build, TaskListener listener){
         Map<String, String> envVars = Ghprb.getEnvVars(build, listener);
 
         if (!envVars.containsKey("ghprbUpstreamStatus")) {
-            return false;
+            return null;
         }        
         
-        String jobName = envVars.get("JOB_NAME");
+        GhprbGitHubAuth auth = GhprbTrigger.getDscp()
+                .getGitHubAuth(envVars.get("ghprbCredentialsId"));
+
+        try {
+            GitHub gh = auth.getConnection(build.getProject());
+            repo = gh.getRepository(envVars.get("ghprbGhRepository"));
+            return envVars;
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Unable to connect to GitHub repo", e);
+            return null;
+        }
         
+    }
+
+    private GhprbSimpleStatus returnGhprbSimpleStatus(Map<String, String> envVars) {
         List<GhprbBuildResultMessage> statusMessages = new ArrayList<GhprbBuildResultMessage>(5);
-        
+
         for (GHCommitState state : GHCommitState.values()) {
             String envVar = String.format("ghprb%sMessage", state.name());
             String message = envVars.get(envVar);
             statusMessages.add(new GhprbBuildResultMessage(state, message));
         }
-        
-        String context = envVars.get("commitStatusContext");
-        
-        if (StringUtils.isEmpty(context)) {
-            context = jobName;
-        }
-        
-        Boolean addTestResults = new Boolean(envVars.get("ghprbAddTestResults"));
 
-        statusUpdater = new GhprbSimpleStatus(
+        return new GhprbSimpleStatus(
                 Boolean.valueOf(envVars.get("ghprbShowMatrixStatus")),
                 envVars.get("ghprbCommitStatusContext"),
                 envVars.get("ghprbStatusUrl"),
                 envVars.get("ghprbTriggeredStatus"),
                 envVars.get("ghprbStartedStatus"),
-                addTestResults,
+                new Boolean(envVars.get("ghprbAddTestResults")),
                 statusMessages
         );
-
-        String credentialsId = envVars.get("ghprbCredentialsId");
-        String repoName = envVars.get("ghprbGhRepository");
-        
-        GhprbGitHubAuth auth = GhprbTrigger.getDscp().getGitHubAuth(credentialsId);
-        try {
-            GitHub gh = auth.getConnection(build.getProject());
-            repo = gh.getRepository(repoName);
-            return true;
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "Unable to connect to GitHub repo", e);
-            return false;
-        }
-        
     }
 
     // Sets the status as pending when the job starts and then calls the createCommitStatus method to send it to GitHub
     @Override
     public Environment setUpEnvironment(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener) {
-        if (updateEnvironmentVars(build, listener)) {
+        Map<String, String> envVars = returnEnvironmentVars(build, listener);
+        if (envVars != null) {
             logger.log(Level.FINE, "Job: " + build.getFullDisplayName() + " Attempting to send GitHub commit status");
 
             try {
-                statusUpdater.onEnvironmentSetup(build, listener, repo);
+                returnGhprbSimpleStatus(envVars).onEnvironmentSetup(build, listener, repo);
             } catch (GhprbCommitStatusException e) {
                 e.printStackTrace();
             }
@@ -110,12 +97,13 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
 
     @Override
     public void onStarted(AbstractBuild<?, ?> build, TaskListener listener) {
-        if (!updateEnvironmentVars(build, listener)) {
+        Map<String, String> envVars = returnEnvironmentVars(build, listener);
+        if (envVars == null) {
             return;
         }
 
         try {
-            statusUpdater.onBuildStart(build, listener, repo);
+            returnGhprbSimpleStatus(envVars).onBuildStart(build, listener, repo);
         } catch (GhprbCommitStatusException e) {
             e.printStackTrace();
         }
@@ -124,12 +112,13 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
     // Sets the status to the build result when the job is done, and then calls the createCommitStatus method to send it to GitHub
     @Override
     public void onCompleted(AbstractBuild<?, ?> build, TaskListener listener) {
-        if (!updateEnvironmentVars(build, listener)) {
+        Map<String, String> envVars = returnEnvironmentVars(build, listener);
+        if (envVars == null) {
             return;
         }
 
         try {
-            statusUpdater.onBuildComplete(build, listener, repo);
+            returnGhprbSimpleStatus(envVars).onBuildComplete(build, listener, repo);
         } catch (GhprbCommitStatusException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
A PR to fix issue #345
* Ensure that we're only getting the environmental variables once and create a new instance of GhprbSimpleStatus when we post one, so race conditions don't occur.