### PR TITLE
Avoid comments check if there are no comments

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -418,6 +418,12 @@ public class GhprbPullRequest {
 
     private int checkComments(GHPullRequest ghpr,
                               Date lastUpdatedTime) {
+
+        if (ghpr.getCommentsCount() == 0) {
+            // Avoid the API call. Nothing to do here.
+            return 0;
+        }
+
         int count = 0;
         logger.log(Level.FINEST, "Checking for comments after: {0}", lastUpdatedTime);
         try {

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -362,7 +362,8 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getCreatedAt();
 
-        verify(ghPullRequest, times(2)).getComments();
+        verify(ghPullRequest, times(1)).getComments();
+        verify(ghPullRequest, times(2)).getCommentsCount();
         verify(ghPullRequest, times(1)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
         verify(ghPullRequest, times(1)).getId();
@@ -457,6 +458,7 @@ public class GhprbRepositoryTest {
 
         verify(ghPullRequest, times(1)).getId();
         verify(ghPullRequest, times(1)).getComments();
+        verify(ghPullRequest, times(1)).getCommentsCount();
         verify(ghPullRequest, times(2)).listCommits();
 
         verify(ghPullRequest, times(2)).getBody();
@@ -492,6 +494,7 @@ public class GhprbRepositoryTest {
         List<GHIssueComment> comments = new ArrayList<GHIssueComment>();
         comments.add(comment);
         given(ghPullRequest.getComments()).willReturn(comments);
+        given(ghPullRequest.getCommentsCount()).willReturn(comments.size());
     }
 
     private void mockHeadAndBase() {


### PR DESCRIPTION
The paged comment check is expensive, and when a new PR is opened, there are no comments, so we can avoid the check.  This value is updated whenever the PR data is pulled, so it will be updated properly during non-webhook and webhook scnearios.