### PR TITLE
Pull PR data if necessary when determining mergeability

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -455,6 +455,9 @@ public class GhprbPullRequest {
                 } catch (InterruptedException ex) {
                     break;
                 }
+                // If the mergeability state was unknown, we need
+                // to grab the mergeability state from the server.
+                this.getPullRequest(true);
                 isMergeable = pr.getMergeable();
             }
             mergeable = isMergeable != null && isMergeable;


### PR DESCRIPTION
I fixed a bug in the Java Github API where it would always populate certain fields of the structure regardless of whether they had been pulled before (the case is unmerged PR).  Doing so causes the mergeability check to fail because we will never pull new data.  Instead, if the mergeability is null, grab the PR again.