### PR TITLE
Allow for blacklisting of target branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ job('upstreamJob') {
             autoCloseFailedPullRequests()
             displayBuildErrorsOnDownstreamBuilds()
             whiteListTargetBranches(['master','test', 'test2'])
+            blackListListTargetBranches(['master','test', 'test2'])
             allowMembersOfWhitelistedOrgsAsAdmin()
             extensions {
                 commitStatus {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -236,6 +236,10 @@ public class Ghprb {
         return false;
     }
 
+    List<GhprbBranch> getBlackListTargetBranches() {
+        return trigger.getBlackListTargetBranches();
+    }
+
     List<GhprbBranch> getWhiteListTargetBranches() {
         return trigger.getWhiteListTargetBranches();
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -80,6 +80,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private Boolean autoCloseFailedPullRequests;
     private Boolean displayBuildErrorsOnDownstreamBuilds;
     private List<GhprbBranch> whiteListTargetBranches;
+    private List<GhprbBranch> blackListTargetBranches;
     private String gitHubAuthId;
     private String triggerPhrase;
     private String skipBuildPhrase;
@@ -131,6 +132,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String commentFilePath,
             String skipBuildPhrase,
             List<GhprbBranch> whiteListTargetBranches,
+            List<GhprbBranch> blackListTargetBranches,
             Boolean allowMembersOfWhitelistedOrgsAsAdmin, 
             String msgSuccess, 
             String msgFailure, 
@@ -152,6 +154,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.displayBuildErrorsOnDownstreamBuilds = displayBuildErrorsOnDownstreamBuilds;
         this.skipBuildPhrase = skipBuildPhrase;
         this.whiteListTargetBranches = whiteListTargetBranches;
+        this.blackListTargetBranches = blackListTargetBranches;
         this.gitHubAuthId = gitHubAuthId;
         this.allowMembersOfWhitelistedOrgsAsAdmin = allowMembersOfWhitelistedOrgsAsAdmin;
         this.buildDescTemplate = buildDescTemplate;
@@ -251,7 +254,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                 new String[] { name, String.valueOf(newInstance) });
 
         helper = new Ghprb(this);
-        
+
         if (getUseGitHubHooks()) {
             if (GhprbTrigger.getDscp().getManageWebhooks()) {
                 this.repository.createHook();
@@ -517,11 +520,21 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return displayBuildErrorsOnDownstreamBuilds;
     }
 
-    public List<GhprbBranch> getWhiteListTargetBranches() {
-        if (whiteListTargetBranches == null) {
+    private List<GhprbBranch> normalizeTargetBranches(List<GhprbBranch> branches) {
+        if (branches == null || 
+                (branches.size() == 1 && branches.get(0).getBranch().equals(""))) {
             return new ArrayList<GhprbBranch>();
+        } else {
+            return branches;
         }
-        return whiteListTargetBranches;
+    }
+
+    public List<GhprbBranch> getWhiteListTargetBranches() {
+        return normalizeTargetBranches(whiteListTargetBranches);
+    }
+
+    public List<GhprbBranch> getBlackListTargetBranches() {
+        return normalizeTargetBranches(blackListTargetBranches);
     }
 
     @Override
@@ -630,6 +643,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private Boolean manageWebhooks = true;
         private GHCommitState unstableAs = GHCommitState.FAILURE;
         private List<GhprbBranch> whiteListTargetBranches;
+        private List<GhprbBranch> blackListTargetBranches;
         private Boolean autoCloseFailedPullRequests = false;
         private Boolean displayBuildErrorsOnDownstreamBuilds = false;
         
@@ -925,6 +939,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             return whiteListTargetBranches;
         }
         
+        public List<GhprbBranch> getBlackListTargetBranches() {
+            return blackListTargetBranches;
+        }
 
         @Deprecated
         private transient String publishedURL;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -33,6 +33,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 context.skipBuildPhrase,
                 context.whiteListTargetBranches,
+                context.blackListTargetBranches,
                 context.allowMembersOfWhitelistedOrgsAsAdmin,
                 null,
                 null,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -12,6 +12,7 @@ class GhprbTriggerContext implements Context {
     List<String> userWhitelist = new ArrayList<String>();
     List<String> orgWhitelist = new ArrayList<String>();
     List<GhprbBranch> whiteListTargetBranches = new ArrayList<GhprbBranch>();
+    List<GhprbBranch> blackListTargetBranches = new ArrayList<GhprbBranch>();
     String cron = "H/5 * * * *";
     String triggerPhrase;
     String skipBuildPhrase;
@@ -71,7 +72,6 @@ class GhprbTriggerContext implements Context {
         }
     }
 
-
     /**
      * Add branch names whose they are considered whitelisted for this specific job
      */
@@ -80,11 +80,27 @@ class GhprbTriggerContext implements Context {
     }
 
     /**
+     * Add branch names whose they are considered blacklisted for this specific job
+     */
+    public void blackListTargetBranch(String branch) {
+        blackListTargetBranches.add(new GhprbBranch(branch));
+    }
+
+    /**
      * Add branch names whose they are considered whitelisted for this specific job
      */
     public void whiteListTargetBranches(Iterable<String> branches) {
         for (String branch : branches) {
             whiteListTargetBranches.add(new GhprbBranch(branch));
+        }
+    }
+
+    /**
+     * Add branch names whose they are considered blacklisted for this specific job
+     */
+    public void blackListTargetBranches(Iterable<String> branches) {
+        for (String branch : branches) {
+            blackListTargetBranches.add(new GhprbBranch(branch));
         }
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -59,6 +59,20 @@ f.advanced() {
       }
     }
   }
+  f.entry(field: "blackListTargetBranches", title: _("Blacklist Target Branches:")) {
+    f.repeatable(field: "blackListTargetBranches", minimum: "1", add: "Add Branch") {
+      table(width: "100%") {
+        f.entry(field: "branch") {
+          f.textbox() 
+        }
+        f.entry(title: "") {
+          div(align: "right") {
+            f.repeatableDeleteButton(value: "Delete Branch") 
+          }
+        }
+      }
+    }
+  }
 }
 f.advanced(title: _("Trigger Setup")) {
   f.entry(title: _("Trigger Setup")) {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-blackListTargetBranches.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-blackListTargetBranches.html
@@ -1,0 +1,4 @@
+<div>
+  Adding branches to this blacklist allows you to prevent pull requests for specific branches.<br/>
+  Supports regular expressions (e.g. 'master', 'feature-.*').
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -210,13 +210,14 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getNumber();
         verify(ghPullRequest, times(1)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getUser();
-        verify(ghPullRequest, times(1)).getBase();
+        verify(ghPullRequest, times(2)).getBase();
         verify(ghPullRequest, times(1)).getComments();
 //        verify(ghPullRequest, times(1)).getCommentsCount();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper).ifOnlyTriggerPhrase();
         verify(helper).getWhiteListTargetBranches();
+        verify(helper).getBlackListTargetBranches();
         verify(helper, times(2)).isProjectDisabled();
         verify(helper).checkSkipBuild(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
@@ -274,7 +275,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(3)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(4)).getBase();
+        verify(ghPullRequest, times(6)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(2)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getCreatedAt();
@@ -288,6 +289,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).getBlackListTargetBranches();
         verify(helper, times(4)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
@@ -357,7 +359,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
-        verify(ghPullRequest, times(4)).getBase();
+        verify(ghPullRequest, times(6)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(1)).getHtmlUrl();
         verify(ghPullRequest, times(2)).getUpdatedAt();
@@ -374,6 +376,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).getBlackListTargetBranches();
 
         // verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -451,7 +454,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(9)).getHead();
-        verify(ghPullRequest, times(5)).getBase();
+        verify(ghPullRequest, times(7)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(2)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getCreatedAt();
@@ -469,6 +472,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).getBlackListTargetBranches();
 
         verify(helper).isWhitelistPhrase(eq("test this please"));
         verify(helper).isOktotestPhrase(eq("test this please"));


### PR DESCRIPTION
This allows for more flexible PR building, since you can say that a PR builds for everything except for specific branches.  While this may be able to be done using the current setup and some complicated regular expressions, I think have a clear blacklist is a more ideal implementation.