### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -76,7 +76,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
         String payload = null;
         String body = null;
 
-        if (type.toLowerCase().startsWith("application/json")) {
+        if (type != null && type.toLowerCase().startsWith("application/json")) {
             body = extractRequestBody(req);
             if (body == null) {
                 logger.log(Level.SEVERE, "Can't get request body for application/json.");
@@ -84,7 +84,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
                 return;
             }
             payload = body;
-        } else if (type.toLowerCase().startsWith("application/x-www-form-urlencoded")) {
+        } else if (type != null && type.toLowerCase().startsWith("application/x-www-form-urlencoded")) {
             body = extractRequestBody(req);
             if (body == null || body.length() <= 8) {
                 logger.log(Level.SEVERE,


### PR DESCRIPTION
```
java.lang.NullPointerException
	at org.jenkinsci.plugins.ghprb.GhprbRootAction.doIndex(GhprbRootAction.java:79)
	at sun.reflect.GeneratedMethodAccessor828.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:320)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:163)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:96)
	at org.kohsuke.stapler.IndexDispatcher.dispatch(IndexDispatcher.java:26)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:746)
	... 69 more
```