### PR TITLE
update 'mergeGithubPullRequest' to 'mergePullRequest' in Job DSL sect…

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ job('upstreamJob') {
         }
     }
     publishers {
-        mergeGithubPullRequest {
+        mergePullRequest {
             mergeComment('merged by Jenkins')
             onlyAdminsMerge()
             disallowOwnCode()


### PR DESCRIPTION
…ion of README

Follows same as [this merged pull request](https://github.com/jenkinsci/ghprb-plugin/pull/276)

Using mergeGithubPullRequest results in following error:
```
Caused by: javaposse.jobdsl.dsl.DslScriptException: (script.groovy, line 27) No signature of method: javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.mergeGithubPullRequest() is applicable for argument types: (helpers.script$_pullRequestTrigger_closure1_closure6_closure8) values: [helpers.script$_pullRequestTrigger_closure1_closure6_closure8@62e136d3]
``` 

Using mergePullRequest builds the xml file and throws deprecation error:
`Warning: (script.groovy, line 27) mergePullRequest is deprecated`