### PR TITLE
 Merge only works when trigger phrase is present #257 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ job('upstreamJob') {
     }
 
     triggers {
-        pullRequest {
+        githubPullRequest {
             admin('user_1')
             admins(['user_2', 'user_3'])
             userWhitelist('you@you.com')

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ job('upstreamJob') {
         }
     }
     publishers {
-        mergePullRequest {
+        mergeGithubPullRequest {
             mergeComment('merged by Jenkins')
             onlyAdminsMerge()
             disallowOwnCode()

--- a/pom.xml
+++ b/pom.xml
@@ -26,17 +26,16 @@
             <name>Valdis Rigdon</name>
         </developer>
     </developers>
-
     <scm>
-        <connection>scm:git:ssh://github.com/dulvac/ghprb-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/dulvac/ghprb-plugin.git</developerConnection>
-        <url>https://github.com/dulvac/ghprb-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/ghprb-plugin</url>
     </scm>
+
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/dulvac/ghprb/issues</url>
+        <url>https://github.com/janinko/ghprb/issues</url>
     </issueManagement>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,15 @@
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/ghprb-plugin</url>
+        <connection>scm:git:ssh://github.com/dulvac/ghprb-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/dulvac/ghprb-plugin.git</developerConnection>
+        <url>https://github.com/dulvac/ghprb-plugin</url>
         <tag>HEAD</tag>
     </scm>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/janinko/ghprb/issues</url>
+        <url>https://github.com/dulvac/ghprb/issues</url>
     </issueManagement>
 
     <properties>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -36,21 +36,24 @@ import hudson.util.FormValidation;
 public class GhprbPullRequestMerge extends Recorder {
 
     private transient PrintStream logger;
-
     private final Boolean onlyAdminsMerge;
+
     private final Boolean disallowOwnCode;
     private final String mergeComment;
     private final Boolean failOnNonMerge;
     private final Boolean deleteOnMerge;
+    private final Boolean allowMergeWithoutTriggerPhrase;
 
     @DataBoundConstructor
-    public GhprbPullRequestMerge(String mergeComment, boolean onlyAdminsMerge, boolean disallowOwnCode, boolean failOnNonMerge, boolean deleteOnMerge) {
+    public GhprbPullRequestMerge(String mergeComment, boolean onlyAdminsMerge, boolean disallowOwnCode, boolean failOnNonMerge,
+                                 boolean deleteOnMerge, boolean allowMergeWithoutTriggerPhrase) {
 
         this.mergeComment = mergeComment;
         this.onlyAdminsMerge = onlyAdminsMerge;
         this.disallowOwnCode = disallowOwnCode;
         this.failOnNonMerge = failOnNonMerge;
         this.deleteOnMerge = deleteOnMerge;
+        this.allowMergeWithoutTriggerPhrase = allowMergeWithoutTriggerPhrase;
     }
 
     public String getMergeComment() {
@@ -71,6 +74,10 @@ public class GhprbPullRequestMerge extends Recorder {
 
     public boolean getDeleteOnMerge() {
         return deleteOnMerge == null ? false : deleteOnMerge;
+    }
+
+    public Boolean getAllowMergeWithoutTriggerPhrase() {
+        return allowMergeWithoutTriggerPhrase == null ? false : allowMergeWithoutTriggerPhrase;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -125,9 +132,8 @@ public class GhprbPullRequestMerge extends Recorder {
         boolean canMerge = true;
         String commentBody = cause.getCommentBody();
 
-        // If merge can only be triggered by a comment and there is a
-        // comment
-        if (commentBody == null || !helper.isTriggerPhrase(commentBody)) {
+        // If merge can only be triggered by a comment and there is a comment
+        if (!getAllowMergeWithoutTriggerPhrase() && (commentBody == null || !helper.isTriggerPhrase(commentBody))) {
             logger.println("The comment does not contain the required trigger phrase.");
         } else {
             intendToMerge = true;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -53,8 +53,8 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 context.onlyAdminsMerge,
                 context.disallowOwnCode,
                 context.failOnNonMerge,
-                context.deleteOnMerge
-        );
+                context.deleteOnMerge,
+                context.allowMergeWithoutTriggerPhrase);
     }
 
     @DslExtensionMethod(context = WrapperContext.class)

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbPullRequestMergeContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbPullRequestMergeContext.java
@@ -8,6 +8,7 @@ public class GhprbPullRequestMergeContext implements Context {
     boolean disallowOwnCode;
     boolean failOnNonMerge;
     boolean deleteOnMerge;
+    boolean allowMergeWithoutTriggerPhrase;
 
     /**
      * @param mergeComment Sets a comment that should show up when the merge command is sent to GitHub.
@@ -70,5 +71,20 @@ public class GhprbPullRequestMergeContext implements Context {
      */
     public void deleteOnMerge() {
         deleteOnMerge(true);
+    }
+
+    /**
+     * Allows merging the PR even if the trigger phrase was not present. Defaults to {@code false}
+     * @param allowMergeWithoutTriggerPhrase
+     */
+    public void allowMergeWithoutTriggerPhrase(boolean allowMergeWithoutTriggerPhrase) {
+        this.allowMergeWithoutTriggerPhrase = allowMergeWithoutTriggerPhrase;
+    }
+
+    /**
+     * Allows merging the PR even if the trigger phrase was not present. Defaults to {@code false}
+     */
+    public void allowMergeWithoutTriggerPhrase() {
+        allowMergeWithoutTriggerPhrase(false);
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/config.jelly
@@ -15,4 +15,7 @@
     <f:entry title="Delete the branch after successful merge?" field="deleteOnMerge">
         <f:checkbox />
     </f:entry>
+    <f:entry title="Allow merge without trigger phrase?" field="allowMergeWithoutTriggerPhrase">
+            <f:checkbox />
+        </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/help-allowMergeWithoutTriggerPhrase.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge/help-allowMergeWithoutTriggerPhrase.html
@@ -1,0 +1,4 @@
+<div>
+	Allow merging even if the trigger phrase is not present.
+	This can be used with the permitAll ("Build every pull request automatically without asking (Dangerous!).")
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -209,7 +209,8 @@ public class GhprbPullRequestMergeTest {
             boolean onlyAdminsMerge, 
             boolean disallowOwnCode,
             boolean failOnNonMerge,
-            boolean deleteOnMerge
+            boolean deleteOnMerge,
+            boolean allowMergeWithoutTriggerPhrase
             ) {
 
         GhprbPullRequestMerge merger = spy(new GhprbPullRequestMerge(
@@ -217,7 +218,8 @@ public class GhprbPullRequestMergeTest {
                 onlyAdminsMerge, 
                 disallowOwnCode,
                 failOnNonMerge,
-                deleteOnMerge));
+                deleteOnMerge,
+                allowMergeWithoutTriggerPhrase));
 
         merger.setHelper(helper);
 
@@ -228,7 +230,7 @@ public class GhprbPullRequestMergeTest {
     private GhprbPullRequestMerge setupMerger(
             boolean onlyAdminsMerge, 
             boolean disallowOwnCode) {
-        return setupMerger(onlyAdminsMerge, disallowOwnCode, false, false);
+        return setupMerger(onlyAdminsMerge, disallowOwnCode, false, false, false);
     }
 
     @Test


### PR DESCRIPTION
Adds a new checkbox parameter to the merger post build action that allows merging without a trigger phrase if configured like that.