### PR TITLE
Add build description template to Job DSL extension

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -38,7 +38,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 null,
                 null,
-                null,
+                context.buildDescriptionTemplate,
                 context.extensionContext.extensions
         );
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -21,6 +21,7 @@ class GhprbTriggerContext implements Context {
     boolean autoCloseFailedPullRequests;
     boolean allowMembersOfWhitelistedOrgsAsAdmin;
     boolean displayBuildErrorsOnDownstreamBuilds;
+    String buildDescriptionTemplate;
     GhprbExtensionContext extensionContext = new GhprbExtensionContext();
 
     /**
@@ -191,6 +192,13 @@ class GhprbTriggerContext implements Context {
      */
     public void displayBuildErrorsOnDownstreamBuilds() {
         displayBuildErrorsOnDownstreamBuilds(true);
+    }
+
+    /**
+     * When filled, changes the default build description template
+     */
+    public void buildDescriptionTemplate(String template) {
+       this.buildDescriptionTemplate = template;
     }
 
     /**


### PR DESCRIPTION
This PR adds supports of setting the build description template in Job DSL extension