### PR TITLE
Do not throw NPE if ghprbGhRepository wasn't passed by upstream job

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
@@ -40,7 +40,7 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
     private Map<String, String> returnEnvironmentVars(AbstractBuild<?, ?> build, TaskListener listener){
         Map<String, String> envVars = Ghprb.getEnvVars(build, listener);
 
-        if (!envVars.containsKey("ghprbUpstreamStatus")) {
+        if (!(envVars.containsKey("ghprbUpstreamStatus") && envVars.containsKey("ghprbGhRepository"))) {
             return null;
         }        
         


### PR DESCRIPTION
Commit status will still not be added, but this avoid throwing NPEs.
