### PR TITLE
Fix mockito usage in test.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
@@ -142,7 +142,7 @@ public class GhprbRootActionTest {
         GHIssueComment ghIssueComment = spy(issueComment.getComment());
         
         Mockito.when(issueComment.getComment()).thenReturn(ghIssueComment);
-        Mockito.when(ghIssueComment.getUser()).thenReturn(ghUser);
+        Mockito.doReturn(ghUser).when(ghIssueComment).getUser();
         
         
         given(trigger.getGitHub().parseEventPayload(Mockito.any(Reader.class), Mockito.eq(IssueComment.class))).willReturn(issueComment);


### PR DESCRIPTION
This test fails when running tests without an internet connection. The
following is an example stacktrace:

```
java.net.UnknownHostException: api.github.com
    at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:178)
    at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
    at java.net.Socket.connect(Socket.java:579)
    at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:618)
    at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
    at sun.net.www.http.HttpClient.openServer(HttpClient.java:432)
    at sun.net.www.http.HttpClient.openServer(HttpClient.java:527)
    at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:275)
    at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:371)
    at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:191)
    at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:932)
    at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:177)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1300)
    at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:468)
    at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:338)
    at org.kohsuke.github.Requester.parse(Requester.java:479)
    at org.kohsuke.github.Requester._to(Requester.java:236)
    at org.kohsuke.github.Requester.to(Requester.java:203)
    at org.kohsuke.github.GitHub.getUser(GitHub.java:290)
    at org.kohsuke.github.GHIssueComment.getUser(GHIssueComment.java:71)
    at org.kohsuke.github.GHIssueComment$$EnhancerByMockitoWithCGLIB$$67157c7c.CGLIB$getUser$6(<generated>)
    at org.kohsuke.github.GHIssueComment$$EnhancerByMockitoWithCGLIB$$67157c7c$$FastClassByMockitoWithCGLIB$$264ca5b3.invoke(<generated>)
    at org.mockito.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:216)
    at org.mockito.internal.creation.cglib.DelegatingMockitoMethodProxy.invokeSuper(DelegatingMockitoMethodProxy.java:19)
    at org.mockito.internal.invocation.realmethod.DefaultRealMethod.invoke(DefaultRealMethod.java:21)
    at org.mockito.internal.invocation.realmethod.CleanTraceRealMethod.invoke(CleanTraceRealMethod.java:30)
    at org.mockito.internal.invocation.InvocationImpl.callRealMethod(InvocationImpl.java:112)
    at org.mockito.internal.stubbing.answers.CallsRealMethods.answer(CallsRealMethods.java:41)
    at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:93)
    at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
    at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:38)
    at org.mockito.internal.creation.cglib.MethodInterceptorFilter.intercept(MethodInterceptorFilter.java:59)
    at org.kohsuke.github.GHIssueComment$$EnhancerByMockitoWithCGLIB$$67157c7c.getUser(<generated>)
    at org.jenkinsci.plugins.ghprb.GhprbRootActionTest.testUrlEncoded(GhprbRootActionTest.java:145)
```