### PR TITLE
Add coverage. Note: You have to opt-in to run it.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>plain-credentials</artifactId>
             <version>1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>cobertura-maven-plugin</artifactId>
+            <version>2.7</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -173,6 +178,16 @@
             </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/janinko/ghprb/issues</url>
+        <url>https://github.com/jenkinsci/ghprb-plugin/issues</url>
     </issueManagement>
 
     <properties>


### PR DESCRIPTION
This won't be run automatically on CI, but can be used locally. Run "mvn cobertura" and
find the results in `target/site/cobertura`
