### PR TITLE
Escaped text in the pull title, so it can be safely used in scripts.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -357,7 +357,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         values.add(new StringParameterValue("ghprbPullAuthorLoginMention", "@" + cause.getPullRequestAuthor().getLogin()));
         
         values.add(new StringParameterValue("ghprbPullDescription", escapeText(String.valueOf(cause.getShortDescription()))));
-        values.add(new StringParameterValue("ghprbPullTitle", String.valueOf(cause.getTitle())));
+        values.add(new StringParameterValue("ghprbPullTitle", escapeText(String.valueOf(cause.getTitle()))));
         values.add(new StringParameterValue("ghprbPullLink", String.valueOf(cause.getUrl())));
         values.add(new StringParameterValue("ghprbPullLongDescription", escapeText(String.valueOf(cause.getDescription()))));
         


### PR DESCRIPTION
The ghprbPullTitle field not being escaped is causing issues with scripts that attempt to use the title, causing random failures based on the title of the pull request. Further, because the issues are at the script level, you can't work around the issue in the script itself. An example of a bug caused by this is https://github.com/dotnet/roslyn/issues/14480. This ports https://github.com/janinko/ghprb/pull/426.