### PR TITLE
Add whitelist label option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ For more details, see https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+re
   * The phrase for adding users to the whitelist via comment. (Java regexp)  
   * The phrase for accepting a pull request for testing. (Java regexp)
   * The phrase for starting a new build. (Java regexp)  
-  * The crontab line. This specify default setting for new jobs.  
+  * The crontab line. This specify default setting for new jobs.
+  * Github labels for which the build will not be triggered (Separated by newline characters)
 * Under Application Setup
   * There are global and job default extensions that can be configured for things like:
     * Commit status updates

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.75</version>
+            <version>1.82</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -156,7 +156,17 @@ public class Ghprb {
         }
         return null;
     }
-    
+
+    public Set<String> getLabelsIgnoreList() {
+        String labelsField = getTrigger().getLabelsIgnoreList();
+        Set<String> labels = new HashSet<String>();
+        if (labelsField != null) {
+            String[] split = labelsField.split("\\n+");
+            Collections.addAll(labels, split);
+        }
+        return labels;
+    }
+
     private Pattern whitelistPhrasePattern() {
         return compilePattern(trigger.getDescriptor().getWhitelistPhrase());
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -157,10 +157,17 @@ public class Ghprb {
         return null;
     }
 
-    public Set<String> getLabelsIgnoreList() {
-        String labelsField = getTrigger().getLabelsIgnoreList();
+    public Set<String> getBlackListLabels() {
+        return spiltLabels(getTrigger().getBlackListLabels());
+    }
+
+    public Set<String> getWhiteListLabels() {
+        return spiltLabels(getTrigger().getWhiteListLabels());
+    }
+
+    private Set<String> spiltLabels(String labelsField) {
         Set<String> labels = new HashSet<String>();
-        if (labelsField != null) {
+        if (labelsField != null && !labelsField.trim().isEmpty()) {
             String[] split = labelsField.split("\\n+");
             Collections.addAll(labels, split);
         }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -91,7 +91,6 @@ public class GhprbPullRequest {
     private String base;
     private boolean accepted = false; // Needed to see if the PR has been added to the accepted list
     private String lastBuildId;
-    private boolean isDirtyPullRequest = false;
 
     // Sets the updated time of the PR.  If the updated time is newer,
     // return true, false otherwise.
@@ -170,14 +169,12 @@ public class GhprbPullRequest {
         checkSkipBuild();
         checkBlackListLabels();
         checkWhiteListLabels();
-        checkDirtyPullRequest();
         tryBuild();
     }
 
     private void checkBlackListLabels() {
         Set<String> labelsToIgnore = helper.getBlackListLabels();
         if (labelsToIgnore != null && !labelsToIgnore.isEmpty()) {
-            isDirtyPullRequest = true;
             try {
                 for (GHLabel label : pr.getLabels()) {
                     if (labelsToIgnore.contains(label.getName())) {
@@ -196,7 +193,6 @@ public class GhprbPullRequest {
     private void checkWhiteListLabels() {
         Set<String> labelsMustContain = helper.getWhiteListLabels();
         if (labelsMustContain != null && !labelsMustContain.isEmpty()) {
-            isDirtyPullRequest = true;
             boolean containsWhiteListLabel = false;
             try {
                 for (GHLabel label : pr.getLabels()) {
@@ -214,18 +210,6 @@ public class GhprbPullRequest {
                 }
             } catch(IOException e) {
                 logger.log(Level.SEVERE, "Failed to read whitelist labels", e);
-            }
-        }
-    }
-
-    private void checkDirtyPullRequest() {
-        if (isDirtyPullRequest) {
-            synchronized (this) {
-                try {
-                    this.pr = getPullRequest(true);
-                } catch (IOException e) {
-                    logger.log(Level.SEVERE, "Error while reloading pull request.", e);
-                }
             }
         }
     }
@@ -252,7 +236,6 @@ public class GhprbPullRequest {
         checkSkipBuild();
         checkBlackListLabels();
         checkWhiteListLabels();
-        checkDirtyPullRequest();
         tryBuild();
     }
     

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.github.GHCommitPointer;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueComment;
+import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHUser;
@@ -17,6 +18,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -165,7 +167,27 @@ public class GhprbPullRequest {
         // Call update PR with the update PR info and no comment
         updatePR(ghpr, null /*GHIssueComment*/, isWebhook);
         checkSkipBuild();
+        checkLabels();
         tryBuild();
+    }
+
+    private void checkLabels() {
+        Set<String> labelsToIgnore = helper.getLabelsIgnoreList();
+        if (labelsToIgnore != null && !labelsToIgnore.isEmpty()) {
+            try {
+                for (GHLabel label : pr.getLabels()) {
+                    if (labelsToIgnore.contains(label.getName())) {
+                        logger.log(Level.INFO,
+                                "Found label {0} in ignore list, pull request will be ignored.",
+                                label.getName());
+                        shouldRun = false;
+                    }
+                }
+
+            } catch(IOException e) {
+                logger.log(Level.SEVERE, "Failed to read labels", e);
+            }
+        }
     }
 
     private void checkSkipBuild() {
@@ -188,6 +210,7 @@ public class GhprbPullRequest {
 
         updatePR(null /*GHPullRequest*/, comment, true);
         checkSkipBuild();
+        checkLabels();
         tryBuild();
     }
     

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -84,6 +84,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private String gitHubAuthId;
     private String triggerPhrase;
     private String skipBuildPhrase;
+    private String labelsIgnoreList;
     
 
     private transient Ghprb helper;
@@ -139,6 +140,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String commitStatusContext,
             String gitHubAuthId,
             String buildDescTemplate,
+            String labelsIgnoreList,
             List<GhprbExtension> extensions
             ) throws ANTLRException {
         super(cron);
@@ -158,6 +160,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.gitHubAuthId = gitHubAuthId;
         this.allowMembersOfWhitelistedOrgsAsAdmin = allowMembersOfWhitelistedOrgsAsAdmin;
         this.buildDescTemplate = buildDescTemplate;
+        this.labelsIgnoreList = labelsIgnoreList;
         setExtensions(extensions);
         configVersion = latestVersion;
     }
@@ -485,6 +488,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return skipBuildPhrase;
     }
 
+    public String getLabelsIgnoreList() {
+        return labelsIgnoreList;
+    }
+
     public Boolean getOnlyTriggerPhrase() {
         return onlyTriggerPhrase != null && onlyTriggerPhrase;
     }
@@ -646,6 +653,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private List<GhprbBranch> blackListTargetBranches;
         private Boolean autoCloseFailedPullRequests = false;
         private Boolean displayBuildErrorsOnDownstreamBuilds = false;
+        private String labelsIgnoreList;
         
         private List<GhprbGitHubAuth> githubAuth;
         
@@ -758,6 +766,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             unstableAs = GHCommitState.valueOf(formData.getString("unstableAs"));
             autoCloseFailedPullRequests = formData.getBoolean("autoCloseFailedPullRequests");
             displayBuildErrorsOnDownstreamBuilds = formData.getBoolean("displayBuildErrorsOnDownstreamBuilds");
+            labelsIgnoreList = formData.getString("labelsIgnoreList");
             
             githubAuth = req.bindJSONToList(GhprbGitHubAuth.class, formData.get("githubAuth"));
             
@@ -834,6 +843,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         public Boolean getUseDetailedComments() {
             return useDetailedComments;
+        }
+
+        public String getLabelsIgnoreList() {
+            return labelsIgnoreList;
         }
 
         public Boolean getManageWebhooks() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -84,7 +84,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private String gitHubAuthId;
     private String triggerPhrase;
     private String skipBuildPhrase;
-    private String labelsIgnoreList;
+    private String blackListLabels;
+    private String whiteListLabels;
     
 
     private transient Ghprb helper;
@@ -140,7 +141,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String commitStatusContext,
             String gitHubAuthId,
             String buildDescTemplate,
-            String labelsIgnoreList,
+            String blackListLabels,
+            String whiteListLabels,
             List<GhprbExtension> extensions
             ) throws ANTLRException {
         super(cron);
@@ -160,7 +162,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.gitHubAuthId = gitHubAuthId;
         this.allowMembersOfWhitelistedOrgsAsAdmin = allowMembersOfWhitelistedOrgsAsAdmin;
         this.buildDescTemplate = buildDescTemplate;
-        this.labelsIgnoreList = labelsIgnoreList;
+        this.blackListLabels = blackListLabels;
+        this.whiteListLabels = whiteListLabels;
         setExtensions(extensions);
         configVersion = latestVersion;
     }
@@ -488,8 +491,12 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return skipBuildPhrase;
     }
 
-    public String getLabelsIgnoreList() {
-        return labelsIgnoreList;
+    public String getBlackListLabels() {
+        return blackListLabels;
+    }
+
+    public String getWhiteListLabels() {
+        return whiteListLabels;
     }
 
     public Boolean getOnlyTriggerPhrase() {
@@ -653,7 +660,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private List<GhprbBranch> blackListTargetBranches;
         private Boolean autoCloseFailedPullRequests = false;
         private Boolean displayBuildErrorsOnDownstreamBuilds = false;
-        private String labelsIgnoreList;
+        private String blackListLabels;
+        private String whiteListLabels;
         
         private List<GhprbGitHubAuth> githubAuth;
         
@@ -766,7 +774,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             unstableAs = GHCommitState.valueOf(formData.getString("unstableAs"));
             autoCloseFailedPullRequests = formData.getBoolean("autoCloseFailedPullRequests");
             displayBuildErrorsOnDownstreamBuilds = formData.getBoolean("displayBuildErrorsOnDownstreamBuilds");
-            labelsIgnoreList = formData.getString("labelsIgnoreList");
+            blackListLabels = formData.getString("blackListLabels");
+            whiteListLabels = formData.getString("whiteListLabels");
             
             githubAuth = req.bindJSONToList(GhprbGitHubAuth.class, formData.get("githubAuth"));
             
@@ -845,8 +854,12 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             return useDetailedComments;
         }
 
-        public String getLabelsIgnoreList() {
-            return labelsIgnoreList;
+        public String getBlackListLabels() {
+            return blackListLabels;
+        }
+
+        public String getWhiteListLabels() {
+            return whiteListLabels;
         }
 
         public Boolean getManageWebhooks() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -39,6 +39,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 null,
                 null,
+                null,
                 context.buildDescriptionTemplate,
                 context.extensionContext.extensions
         );

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -40,8 +40,8 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 null,
                 context.buildDescriptionTemplate,
-                null,
-                null,
+                context.blackListLabels,
+                context.whiteListLabels,
                 context.extensionContext.extensions
         );
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -39,8 +39,9 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 null,
                 null,
-                null,
                 context.buildDescriptionTemplate,
+                null,
+                null,
                 context.extensionContext.extensions
         );
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -13,6 +13,8 @@ class GhprbTriggerContext implements Context {
     List<String> orgWhitelist = new ArrayList<String>();
     List<GhprbBranch> whiteListTargetBranches = new ArrayList<GhprbBranch>();
     List<GhprbBranch> blackListTargetBranches = new ArrayList<GhprbBranch>();
+    String blackListLabels;
+    String whiteListLabels;
     String cron = "H/5 * * * *";
     String triggerPhrase;
     String skipBuildPhrase;
@@ -85,6 +87,20 @@ class GhprbTriggerContext implements Context {
      */
     public void blackListTargetBranch(String branch) {
         blackListTargetBranches.add(new GhprbBranch(branch));
+    }
+
+    /**
+     * Set label lists whose they are considered whitelisted for this specific job
+     */
+    public void whiteListLabels(String whiteListLabels) {
+        this.whiteListLabels = whiteListLabels;
+    }
+
+    /**
+     * Set label lists whose they are considered blacklisted for this specific job
+     */
+    public void blackListLabels(String blackListLabels) {
+        this.blackListLabels = blackListLabels;
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -36,6 +36,9 @@ f.advanced() {
   f.entry(field: "orgslist", title: _("List of organizations. Their members will be whitelisted.")) {
     f.textarea() 
   }
+  f.entry(field: "labelsIgnoreList", title: _("List of github labels for which the build should not be triggered.")) {
+    f.textarea()
+  }
   f.entry(field: "allowMembersOfWhitelistedOrgsAsAdmin", title: "Allow members of whitelisted organizations as admins") {
     f.checkbox() 
   }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -36,7 +36,10 @@ f.advanced() {
   f.entry(field: "orgslist", title: _("List of organizations. Their members will be whitelisted.")) {
     f.textarea() 
   }
-  f.entry(field: "labelsIgnoreList", title: _("List of github labels for which the build should not be triggered.")) {
+  f.entry(field: "blackListLabels", title: _("List of github labels for which the build should not be triggered.")) {
+    f.textarea()
+  }
+  f.entry(field: "whiteListLabels", title: _("List of github labels for which the build should only be triggered. (Leave blank for 'any')")) {
     f.textarea()
   }
   f.entry(field: "allowMembersOfWhitelistedOrgsAsAdmin", title: "Allow members of whitelisted organizations as admins") {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -36,10 +36,10 @@ f.advanced() {
   f.entry(field: "orgslist", title: _("List of organizations. Their members will be whitelisted.")) {
     f.textarea() 
   }
-  f.entry(field: "blackListLabels", title: _("List of github labels for which the build should not be triggered.")) {
+  f.entry(field: "blackListLabels", title: _("List of GitHub labels for which the build should not be triggered.")) {
     f.textarea()
   }
-  f.entry(field: "whiteListLabels", title: _("List of github labels for which the build should only be triggered. (Leave blank for 'any')")) {
+  f.entry(field: "whiteListLabels", title: _("List of GitHub labels for which the build should only be triggered. (Leave blank for 'any')")) {
     f.textarea()
   }
   f.entry(field: "allowMembersOfWhitelistedOrgsAsAdmin", title: "Allow members of whitelisted organizations as admins") {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -46,6 +46,9 @@ f.section(title: descriptor.displayName) {
     f.entry(field: "cron", title: _("Crontab line"), help: "/descriptor/hudson.triggers.TimerTrigger/help/spec") {
       f.textbox(default: "H/5 * * * *", checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)") 
     }
+    f.entry(field: "labelsIgnoreList", title: _("List of github labels for which the build should not be triggered.")) {
+      f.textarea()
+    }
   }
   f.entry(title: _("Application Setup")) {
     f.hetero_list(items: descriptor.extensions, name: "extensions", oneEach: "true", hasHeader: "true", descriptors: descriptor.getGlobalExtensionDescriptors()) 

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -46,7 +46,10 @@ f.section(title: descriptor.displayName) {
     f.entry(field: "cron", title: _("Crontab line"), help: "/descriptor/hudson.triggers.TimerTrigger/help/spec") {
       f.textbox(default: "H/5 * * * *", checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)") 
     }
-    f.entry(field: "labelsIgnoreList", title: _("List of github labels for which the build should not be triggered.")) {
+    f.entry(field: "blackListLabels", title: _("List of github labels for which the build should not be triggered.")) {
+      f.textarea()
+    }
+    f.entry(field: "whiteListLabels", title: _("List of github labels for which the build should only be triggered. (Leave blank for 'any')")) {
       f.textarea()
     }
   }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -46,10 +46,10 @@ f.section(title: descriptor.displayName) {
     f.entry(field: "cron", title: _("Crontab line"), help: "/descriptor/hudson.triggers.TimerTrigger/help/spec") {
       f.textbox(default: "H/5 * * * *", checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)") 
     }
-    f.entry(field: "blackListLabels", title: _("List of github labels for which the build should not be triggered.")) {
+    f.entry(field: "blackListLabels", title: _("List of GitHub labels for which the build should not be triggered.")) {
       f.textarea()
     }
-    f.entry(field: "whiteListLabels", title: _("List of github labels for which the build should only be triggered. (Leave blank for 'any')")) {
+    f.entry(field: "whiteListLabels", title: _("List of GitHub labels for which the build should only be triggered. (Leave blank for 'any')")) {
       f.textarea()
     }
   }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -275,7 +275,7 @@ public class GhprbRepositoryTest {
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
-        verify(ghRepository, times(3)).getPullRequest(Mockito.anyInt());
+        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -453,7 +453,7 @@ public class GhprbRepositoryTest {
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
-        verify(ghRepository, times(3)).getPullRequest(Mockito.anyInt());
+        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -542,7 +542,7 @@ public class GhprbRepositoryTest {
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
-        verify(ghRepository, times(3)).getPullRequest(Mockito.anyInt());
+        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -642,7 +642,7 @@ public class GhprbRepositoryTest {
         
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
         verify(ghRepository, times(2)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
-        verify(ghRepository, times(3)).getPullRequest(Mockito.anyInt());
+        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -223,7 +223,8 @@ public class GhprbRepositoryTest {
         verify(helper).getBlackListTargetBranches();
         verify(helper, times(2)).isProjectDisabled();
         verify(helper).checkSkipBuild(eq(ghPullRequest));
-        verify(helper, times(1)).getLabelsIgnoreList();
+        verify(helper, times(1)).getBlackListLabels();
+        verify(helper, times(1)).getWhiteListLabels();
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
@@ -260,7 +261,8 @@ public class GhprbRepositoryTest {
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
-        given(helper.getLabelsIgnoreList()).willReturn(Collections.set("bug", "help wanted"));
+        given(helper.getBlackListLabels()).willReturn(Collections.set("bug", "help wanted"));
+        given(helper.getWhiteListLabels()).willReturn(null);
 
         // WHEN
         ghprbRepository.check();
@@ -273,7 +275,7 @@ public class GhprbRepositoryTest {
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
-        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
+        verify(ghRepository, times(3)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -298,7 +300,8 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getBlackListTargetBranches();
         verify(helper, times(4)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
-        verify(helper, times(2)).getLabelsIgnoreList();
+        verify(helper, times(2)).getBlackListLabels();
+        verify(helper, times(2)).getWhiteListLabels();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
@@ -341,7 +344,8 @@ public class GhprbRepositoryTest {
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
-        given(helper.getLabelsIgnoreList()).willReturn(Collections.set("in progress"));
+        given(helper.getBlackListLabels()).willReturn(Collections.set("in progress"));
+        given(helper.getWhiteListLabels()).willReturn(null);
 
         // WHEN
         ghprbRepository.check();
@@ -392,7 +396,8 @@ public class GhprbRepositoryTest {
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
-        given(helper.getLabelsIgnoreList()).willReturn(Collections.set("bug", "help wanted"));
+        given(helper.getBlackListLabels()).willReturn(Collections.set("bug", "help wanted"));
+        given(helper.getWhiteListLabels()).willReturn(null);
 
         // WHEN
         ghprbRepository.check(); // PR was created
@@ -408,7 +413,7 @@ public class GhprbRepositoryTest {
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
-        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
+        verify(ghRepository, times(3)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -434,7 +439,8 @@ public class GhprbRepositoryTest {
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
         verify(helper, times(2)).getBlackListTargetBranches();
-        verify(helper, times(2)).getLabelsIgnoreList();
+        verify(helper, times(2)).getBlackListLabels();
+        verify(helper, times(2)).getWhiteListLabels();
 
         // verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -488,7 +494,8 @@ public class GhprbRepositoryTest {
         given(helper.isRetestPhrase(eq("test this please"))).willReturn(true);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
-        given(helper.getLabelsIgnoreList()).willReturn(Collections.set("bug", "help wanted"));
+        given(helper.getBlackListLabels()).willReturn(Collections.set("bug", "help wanted"));
+        given(helper.getWhiteListLabels()).willReturn(null);
 
         // WHEN
         ghprbRepository.check(); // PR was created
@@ -506,7 +513,7 @@ public class GhprbRepositoryTest {
         
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
         verify(ghRepository, times(2)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
-        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
+        verify(ghRepository, times(3)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
@@ -533,7 +540,8 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
         verify(helper, times(2)).getBlackListTargetBranches();
-        verify(helper, times(2)).getLabelsIgnoreList();
+        verify(helper, times(2)).getBlackListLabels();
+        verify(helper, times(2)).getWhiteListLabels();
 
         verify(helper).isWhitelistPhrase(eq("test this please"));
         verify(helper).isOktotestPhrase(eq("test this please"));

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -319,6 +319,7 @@ public class GhprbTestUtil {
         jsonObject.put("msgSuccess", "Success");
         jsonObject.put("msgFailure", "Failure");
         jsonObject.put("commitStatusContext", "Status Context");
+        jsonObject.put("labelsIgnoreList", "in progress");
         
         JSONObject githubAuth = new JSONObject();
         githubAuth.put("credentialsId", getCredentialsId());

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -319,15 +319,16 @@ public class GhprbTestUtil {
         jsonObject.put("msgSuccess", "Success");
         jsonObject.put("msgFailure", "Failure");
         jsonObject.put("commitStatusContext", "Status Context");
-        jsonObject.put("labelsIgnoreList", "in progress");
-        
+        jsonObject.put("blackListLabels", "in progress");
+        jsonObject.put("whiteListLabels", "");
+
         JSONObject githubAuth = new JSONObject();
         githubAuth.put("credentialsId", getCredentialsId());
         githubAuth.put("serverAPIUrl", apiUrl);
         githubAuth.put("secret", null);
         
         jsonObject.put("githubAuth", githubAuth);
-        
+
 
         for ( Entry<String, Object> next: config.entrySet()) {
             jsonObject.put(next.getKey(), next.getValue());


### PR DESCRIPTION
This adds the `Whitelist label option` to ghprb's advanced options.

* If both Whitelist and Blacklist label options are entered, it works in 'AND' mode. In other words, PR should not have Blacklist label and Whiltelist label should exist.

* If nothing is entered in the Whitelist label option, this option is ignored.

I think adding the Whitelist label option can help solve the #210 issue in the future.

* Bug Fix Included (#441)

1. LabelField's empty string check problem.

Https://github.com/sjstyle/ghprb-plugin/commit/c54a32cb01d897c207a1f531aa3873f8ab70e044#diff-4b618248c9f9a59094a30a1212e2d172R170

Previously this plug-in did not check for Empty on this line. As a result, when the user enters a setting value, a non-null space is input, so the empty collection is always returned and the Label Check part is activated.

2. pr.getLabels method problem.

Https://github.com/sjstyle/ghprb-plugin/commit/c54a32cb01d897c207a1f531aa3873f8ab70e044#diff-70706d3124e337b7f717ad901c08d53aL178

Previously this plugin called the `pr.getLabels ()` method. It seems that we would expect only the labels to be returned because of the `get` prefix, but in fact this method is supposed to do something else.

Https://github.com/kohsuke/github-api/blob/github-api-1.80/src/main/java/org/kohsuke/github/GHPullRequest.java#L130-L133

This is where calling `fetchIssue ()`.

https://github.com/kohsuke/github-api/blob/github-api-1.80/src/main/java/org/kohsuke/github/GHPullRequest.java#L297-L302

It changes `this` in this part. This changes the object from `<api> / {user} / {repo} / pulls` to` <api> / {user} / {repo} / issues`.

I think this is supposed to be the #441 problem.