### PR TITLE
Add support for configuring when a comment file is posted, based on build status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTriggerBackwardsCompatible.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTriggerBackwardsCompatible.java
@@ -36,6 +36,10 @@ public abstract class GhprbTriggerBackwardsCompatible extends Trigger<AbstractPr
     @Deprecated
     protected transient String commentFilePath;
     @Deprecated
+    protected transient Boolean commentFileOnSuccess;
+    @Deprecated
+    protected transient Boolean commentFileOnFailure;
+    @Deprecated
     protected transient String msgSuccess;
     @Deprecated
     protected transient String msgFailure;
@@ -82,7 +86,9 @@ public abstract class GhprbTriggerBackwardsCompatible extends Trigger<AbstractPr
 
     private void checkCommentsFile() {
         if (!StringUtils.isEmpty(commentFilePath)) {
-            GhprbCommentFile comments = new GhprbCommentFile(commentFilePath);
+            GhprbCommentFile comments = new GhprbCommentFile(commentFilePath,
+                    commentFileOnSuccess,
+                    commentFileOnFailure);
             addIfMissing(comments);
             commentFilePath = null;
         }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile/config.groovy
@@ -1,0 +1,12 @@
+j = namespace("jelly:core")
+f = namespace("/lib/form")
+
+f.entry(field: "commentFilePath", title: _("Comment file path")) {
+  f.textbox()
+}
+f.entry(field: "commentFileOnSuccess", title: _("Comment file on Success")) {
+  f.checkbox(default: true)
+}
+f.entry(field: "commentFileOnFailure", title: _("Comment file on Failure")) {
+  f.checkbox(default: true)
+}

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile/config.jelly
@@ -3,4 +3,10 @@
     <f:entry title="${%Comment file path}" field="commentFilePath">
       <f:textbox />
     </f:entry>
+    <f:entry title="Comment file on Success" field="commentFileOnSuccess">
+      <f:checkbox default="${descriptor.commentFileOnSuccess}"/>
+    </f:entry>
+    <f:entry title="Comment file on Failure" field="commentFileOnFailure">
+      <f:checkbox default="${descriptor.commentFileOnFailure}"/>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
Use case:
Only posting a comment, containing the contents of a file, if the build status is a failure _or_ a success.

I have preserved the current behaviour by defaulting the 'on Success' and 'on Failure' checkboxes to true.