### PR TITLE
Consume --none-- in Github commenter.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.ghprb;
 
+import com.google.common.annotations.VisibleForTesting;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.*;
@@ -218,7 +219,8 @@ public class GhprbBuilds {
         }
     }
 
-    private void commentOnBuildResult(Run<?, ?> build, TaskListener listener, GHCommitState state, GhprbCause c) {
+    @VisibleForTesting
+    void commentOnBuildResult(Run<?, ?> build, TaskListener listener, GHCommitState state, GhprbCause c) {
         StringBuilder msg = new StringBuilder();
 
         for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommentAppender.class)) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -223,7 +223,11 @@ public class GhprbBuilds {
 
         for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommentAppender.class)) {
             if (ext instanceof GhprbCommentAppender) {
-                msg.append(((GhprbCommentAppender) ext).postBuildComment(build, listener));
+                String cmt = ((GhprbCommentAppender) ext).postBuildComment(build, listener);
+                if ("--none--".equals(cmt)) {
+                    return;
+                }
+                msg.append(cmt);
             }
         }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbBuildsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbBuildsTest.java
@@ -1,0 +1,92 @@
+package org.jenkinsci.plugins.ghprb;
+
+import hudson.model.Build;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.github.GHCommitState;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.PrintStream;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Unit test for {@link org.jenkinsci.plugins.ghprb.GhprbBuilds}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GhprbBuildsTest {
+
+    @Mock
+    private GhprbRepository repo;
+    @Mock
+    private GhprbCause cause;
+    @Mock
+    private GhprbBuildStatus appender;
+    @Mock
+    private TaskListener listener;
+    @Mock
+    private Build build;
+    @Mock
+    private PrintStream stream;
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    private GhprbTrigger trigger;
+    private GHCommitState state = GHCommitState.SUCCESS;
+
+    @Before
+    public void setup() throws Exception {
+        // Mock trigger and add a mocked appender.
+        trigger = GhprbTestUtil.getTrigger();
+        trigger.getDescriptor().getExtensions().add(appender);
+
+        // Mocks for GhprbRepository
+        doNothing().when(repo).addComment(anyInt(), anyString());
+
+        // Mock out the logger.
+        given(listener.getLogger()).willReturn(stream);
+        doNothing().when(stream).println(anyString());
+    }
+
+    @Test
+    public void testCommentOnBuildResultWithSkip() {
+        String testMessage = "--none--";
+        given(appender.postBuildComment(build, listener)).willReturn(testMessage);
+
+        // WHEN
+        GhprbBuilds builds = new GhprbBuilds(trigger, repo);
+        builds.commentOnBuildResult(build, listener, state, cause);
+
+        // THEN
+        verify(repo, never()).addComment(Mockito.anyInt(), anyString());
+    }
+
+    @Test
+    public void testCommentOnBuildResultNoSkip() {
+        String testMessage = "test";
+        given(appender.postBuildComment(build, listener)).willReturn(testMessage);
+
+        // WHEN
+        GhprbBuilds builds = new GhprbBuilds(trigger, repo);
+        builds.commentOnBuildResult(build, listener, state, cause);
+
+        // THEN
+        verify(repo, times(1)).addComment(cause.getPullID(), testMessage, build, listener);
+    }
+}
+

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbBuildsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbBuildsTest.java
@@ -53,7 +53,7 @@ public class GhprbBuildsTest {
     public void setup() throws Exception {
         // Mock trigger and add a mocked appender.
         trigger = GhprbTestUtil.getTrigger();
-        trigger.getDescriptor().getExtensions().add(appender);
+        trigger.getExtensions().add(appender);
 
         // Mocks for GhprbRepository
         doNothing().when(repo).addComment(anyInt(), anyString());


### PR DESCRIPTION
"--none--" is treated as a special string by the build status component, but not by the component which actually posts back to the PR, leading to PRs which look like this:

https://github.com/apache/beam/pull/1706

This change will ensure the PR post follows the same rules and comes into line with the documentation.

Build Status code is [here](https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java#L211).
Documentation [here](https://github.com/jenkinsci/ghprb-plugin/blob/master/CHANGELOG.md#--128).