### PR TITLE
Update help in app (it's correct in the README).

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-triggerPhrase.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-triggerPhrase.html
@@ -1,3 +1,3 @@
 <div>
-	When filled, commenting this phrase in the pull request will trigger a build.
+	When filled, commenting this phrase in the pull request will trigger a build.  Matches case insensitively and supports regular expressions (e.g. .*(re)?run tests.*).
 </div>


### PR DESCRIPTION
Other fields have an example of a regexp (such as the skip phrase)
or call it out in the Help.

We were excited to realize we could use this feature after an upgrade.