### PR TITLE
Fix issue where multiple PRs won't enqueue

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbParametersAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbParametersAction.java
@@ -21,30 +21,8 @@ import java.util.List;
 @Restricted(NoExternalUse.class)
 public class GhprbParametersAction extends ParametersAction {
 
-    private List<ParameterValue> parameters;
-
     public GhprbParametersAction(List<ParameterValue> parameters) {
-        this.parameters = parameters;
-    }
-
-    public GhprbParametersAction(ParameterValue... parameters) {
-        this(Arrays.asList(parameters));
-    }
-
-    @Override
-    public List<ParameterValue> getParameters() {
-        return Collections.unmodifiableList(parameters);
-    }
-
-    @Override
-    public ParameterValue getParameter(String name) {
-        for (ParameterValue parameter : parameters) {
-            if (parameter != null && parameter.getName().equals(name)) {
-                return parameter;
-            }
-        }
-
-        return null;
+        super(parameters);
     }
 
     @Extension


### PR DESCRIPTION
We ran into this issue while trying to figure out why multiple PRs under the same repo weren't all getting enqueued. Only one would if the build agent was busy. The latter ones would just get ignored. It was behaving correctly before a recent update.

What turned out was happening was when the Queue determines if it should enqueue or not: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Queue.java#L614

Parameterized builds with different parameters should enqueue multiple builds. Like https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/ParametersAction.java#L219 says so

However, that uses the private field `.parameters` and since we subclass it and override methods: https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/GhprbParametersAction.java#L22, we're not updating that super class's private field. 

So I changed GhprbParametersAction to just call `super` and not maintain its own parameters and then this all works as advertised. 😀 