### PR TITLE
Don't use okToTestPhrase as triggerPhrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ job('upstreamJob') {
             orgWhitelist('my_github_org')
             orgWhitelist(['your_github_org', 'another_org'])
             cron('H/5 * * * *')
-            triggerPhrase('OK to test')
+            triggerPhrase('special trigger phrase')
             onlyTriggerPhrase()
             useGitHubHooks()
             permitAll()


### PR DESCRIPTION
I've found the various triggering mechanisms.  Part of my confusion has come from the fact that the example uses the same phrase for `triggerPhrase()` that is defined [in the code for `okToTestPhrase`](https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java#L657).

The fact that the same string was used for both made it very difficult to understand what I was seeing in the logs....