### PR TITLE
[JENKINS-42148] Fix catastrophic backtracking in admin list form validation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -803,7 +803,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         
 
         public FormValidation doCheckAdminlist(@QueryParameter String value) throws ServletException {
-            for (String admin : value.split("\\s")) {
+            for (String admin : value.split("\\p{Space}")) {
                 if (!admin.trim().isEmpty() && !adminlistPattern.matcher(admin).matches()) {
                     return FormValidation.error("GitHub username may only contain alphanumeric characters or dashes "
                             + "and cannot begin with a dash. Separate them with whitespaces.");

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -642,7 +642,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     public static final class DescriptorImpl extends TriggerDescriptor {
         // GitHub username may only contain alphanumeric characters or dashes and cannot begin with a dash
-        private static final Pattern adminlistPattern = Pattern.compile("((\\p{Alnum}[\\p{Alnum}-]*)|\\s)*");
+        private static final Pattern adminlistPattern = Pattern.compile("^\\p{Alnum}[\\p{Alnum}-]*");
         
         private Integer configVersion;
 
@@ -803,10 +803,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         
 
         public FormValidation doCheckAdminlist(@QueryParameter String value) throws ServletException {
-            if (!adminlistPattern.matcher(value).matches()) {
-                return FormValidation.error("GitHub username may only contain alphanumeric characters or dashes "
-                        + "and cannot begin with a dash. Separate them with whitespaces.");
+            for (String admin : value.split("\\s")) {
+                if (!admin.trim().isEmpty() && !adminlistPattern.matcher(admin).matches()) {
+                    return FormValidation.error("GitHub username may only contain alphanumeric characters or dashes "
+                            + "and cannot begin with a dash. Separate them with whitespaces.");
+                }
             }
+
             return FormValidation.ok();
         }
         

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
@@ -14,16 +14,20 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import hudson.util.FormValidation;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbGlobalDefault;
 import org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.github.GHPullRequest;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.ServletException;
 
 /**
  * Unit test for {@link org.jenkinsci.plugins.ghprb.GhprbTriggerTest}.
@@ -144,6 +148,13 @@ public class GhprbTriggerTest {
             }
         }
     }
-    
 
+    @Test
+    @Issue("JENKINS-42148")
+    public void testNoBacktracking() throws ServletException {
+        assertThat(GhprbTrigger.getDscp().doCheckAdminlist("one two three four five six seven eight nine ten.eleven")).isNotEqualTo(FormValidation.ok());
+        assertThat(GhprbTrigger.getDscp().doCheckAdminlist("one two   three four five six seven eight nine ten eleven")).isEqualTo(FormValidation.ok());
+        assertThat(GhprbTrigger.getDscp().doCheckAdminlist("")).isEqualTo(FormValidation.ok());
+        assertThat(GhprbTrigger.getDscp().doCheckAdminlist("       ")).isEqualTo(FormValidation.ok());
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
@@ -153,7 +153,7 @@ public class GhprbTriggerTest {
     @Issue("JENKINS-42148")
     public void testNoBacktracking() throws ServletException {
         assertThat(GhprbTrigger.getDscp().doCheckAdminlist("one two three four five six seven eight nine ten.eleven")).isNotEqualTo(FormValidation.ok());
-        assertThat(GhprbTrigger.getDscp().doCheckAdminlist("one two   three four five six seven eight nine ten eleven")).isEqualTo(FormValidation.ok());
+        assertThat(GhprbTrigger.getDscp().doCheckAdminlist("one two \tthree \nfour five six seven eight nine ten eleven")).isEqualTo(FormValidation.ok());
         assertThat(GhprbTrigger.getDscp().doCheckAdminlist("")).isEqualTo(FormValidation.ok());
         assertThat(GhprbTrigger.getDscp().doCheckAdminlist("       ")).isEqualTo(FormValidation.ok());
     }


### PR DESCRIPTION
In order to prevent backtracking, this patch splits the admin list and
validate that each admin matches the constraint. The regular expression
is simplified so it can't backtrack anymore.

@reviewbybees