### PR TITLE
Skip build on specific user commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ a smoke test job and a full test job, you can configure the full test job to onl
 
 For more details, see https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin
 
-### Master status:
+### Build status (regardless of branch):
 
 [![Build Status](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=plugins/ghprb-plugin)](https://jenkins.ci.cloudbees.com/job/plugins/job/ghprb-plugin/)
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -6,6 +6,14 @@ import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.Util;
 import hudson.matrix.MatrixProject;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Item;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Saveable;
+import hudson.model.StringParameterValue;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.util.BuildData;
@@ -66,6 +74,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private String gitHubAuthId;
     private String triggerPhrase;
     private String skipBuildPhrase;
+    private String blackListCommitAuthor;
     private String blackListLabels;
     private String whiteListLabels;
     
@@ -115,6 +124,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             Boolean displayBuildErrorsOnDownstreamBuilds,
             String commentFilePath,
             String skipBuildPhrase,
+            String blackListCommitAuthor,
             List<GhprbBranch> whiteListTargetBranches,
             List<GhprbBranch> blackListTargetBranches,
             Boolean allowMembersOfWhitelistedOrgsAsAdmin, 
@@ -139,6 +149,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.displayBuildErrorsOnDownstreamBuilds = displayBuildErrorsOnDownstreamBuilds;
         this.skipBuildPhrase = skipBuildPhrase;
+        this.blackListCommitAuthor = blackListCommitAuthor;
         this.whiteListTargetBranches = whiteListTargetBranches;
         this.blackListTargetBranches = blackListTargetBranches;
         this.gitHubAuthId = gitHubAuthId;
@@ -479,6 +490,14 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return skipBuildPhrase;
     }
 
+    public String getBlackListCommitAuthor() {
+        if (StringUtils.isEmpty(blackListCommitAuthor)) {
+            // if it's empty grab the global value
+            return getDescriptor().getBlackListCommitAuthor();
+        }
+        return blackListCommitAuthor;
+    }
+
     public String getBlackListLabels() {
         if (blackListLabels == null) {
             return "";
@@ -644,6 +663,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private String okToTestPhrase = ".*ok\\W+to\\W+test.*";
         private String retestPhrase = ".*test\\W+this\\W+please.*";
         private String skipBuildPhrase = ".*\\[skip\\W+ci\\].*";
+        private String blackListCommitAuthor = "";
         private String cron = "H/5 * * * *";
         private Boolean useComments = false;
         private Boolean useDetailedComments = false;
@@ -760,6 +780,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             okToTestPhrase = formData.getString("okToTestPhrase");
             retestPhrase = formData.getString("retestPhrase");
             skipBuildPhrase = formData.getString("skipBuildPhrase");
+            blackListCommitAuthor = formData.getString("blackListCommitAuthor");
             cron = formData.getString("cron");
             useComments = formData.getBoolean("useComments");
             useDetailedComments = formData.getBoolean("useDetailedComments");
@@ -833,6 +854,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         public String getSkipBuildPhrase() {
             return skipBuildPhrase;
+        }
+
+        public String getBlackListCommitAuthor() {
+            return blackListCommitAuthor;
         }
 
         public String getCron() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -32,6 +32,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 context.displayBuildErrorsOnDownstreamBuilds,
                 null,
                 context.skipBuildPhrase,
+                context.blackListCommitAuthor,
                 context.whiteListTargetBranches,
                 context.blackListTargetBranches,
                 context.allowMembersOfWhitelistedOrgsAsAdmin,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -18,6 +18,7 @@ class GhprbTriggerContext implements Context {
     String cron = "H/5 * * * *";
     String triggerPhrase;
     String skipBuildPhrase;
+    String blackListCommitAuthor;
     boolean onlyTriggerPhrase;
     boolean useGitHubHooks;
     boolean permitAll;
@@ -163,11 +164,20 @@ class GhprbTriggerContext implements Context {
     }
 
     /**
+     * When filled, pull requests comits from this user will be skipped.
+     */
+    public void blackListCommitAuthor(String blackListCommitAuthor) {
+        this.blackListCommitAuthor = blackListCommitAuthor;
+    }
+
+    /**
      * When set, only commenting the trigger phrase in the pull request will trigger a build.
      */
     public void onlyTriggerPhrase(boolean onlyTriggerPhrase) {
         this.onlyTriggerPhrase = onlyTriggerPhrase;
     }
+
+
 
     /**
      * When set, only commenting the trigger phrase in the pull request will trigger a build.

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -25,7 +25,7 @@ f.advanced() {
     f.textbox(default: descriptor.skipBuildPhrase)
   }
   f.entry(field: "displayBuildErrorsOnDownstreamBuilds", title: _("Display build errors on downstream builds?")) {
-    f.checkbox(default: descriptor.displayBuildErrorsOnDownstreamBuilds) 
+    f.checkbox(default: descriptor.displayBuildErrorsOnDownstreamBuilds)
   }
   f.entry(field: "cron", title: _("Crontab line"), help: "/descriptor/hudson.triggers.TimerTrigger/help/spec") {
     f.textbox(default: descriptor.cron, checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)") 
@@ -50,6 +50,9 @@ f.advanced() {
   }
   f.entry(field: "buildDescTemplate", title: _("Build description template")) {
       f.textarea()
+  }
+  f.entry(field: "blackListCommitAuthor", title: _("Blacklist commit authors")) {
+    f.textbox(default: descriptor.blackListCommitAuthor)
   }
   f.entry(field: "whiteListTargetBranches", title: _("Whitelist Target Branches:")) {
     f.repeatable(field: "whiteListTargetBranches", minimum: "1", add: "Add Branch") {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly.tmp
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly.tmp
@@ -45,6 +45,9 @@
     <f:entry title="Build every pull request automatically without asking (Dangerous!)." field="permitAll">
       <f:checkbox />
     </f:entry>
+    <f:entry title="${%Black list commit authors}" field="blackListCommitAuthor">
+  	  <f:textbox default="${descriptor.blackListCommitAuthor}"/>
+    </f:entry>
     <f:entry title="${%Whitelist Target Branches:}" field="whiteListTargetBranches" >
       <f:repeatable field="whiteListTargetBranches" minimum="1"  add="Add Branch" >
         <table width="100%">

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -46,6 +46,9 @@ f.section(title: descriptor.displayName) {
     f.entry(field: "cron", title: _("Crontab line"), help: "/descriptor/hudson.triggers.TimerTrigger/help/spec") {
       f.textbox(default: "H/5 * * * *", checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)") 
     }
+    f.entry(field: "blackListCommitAuthor", title: _("Blacklist commit authors")) {
+      f.textbox(default: "")
+    }
     f.entry(field: "blackListLabels", title: _("List of GitHub labels for which the build should not be triggered.")) {
       f.textarea()
     }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly.tmp
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly.tmp
@@ -43,6 +43,9 @@
       <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
       	<f:textbox default=".*\[skip\W+ci\].*"/>
       </f:entry>
+      <f:entry title="${%Blacklist commit authors}" field="blackListCommitAuthor">
+      	<f:textbox default=""/>
+      </f:entry>
       <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
         <f:textbox default="H/5 * * * *" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
       </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-blackListCommitAuthor.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-blackListCommitAuthor.html
@@ -1,0 +1,4 @@
+<div>
+	When filled, pull request commits from this user(s) will <b>not</b> trigger a build.
+	(Note: this can be overridden by job-specific configuration.)
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -193,6 +193,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).getUser();
         verify(ghPullRequest, times(2)).getBase();
         verify(ghPullRequest, times(1)).getComments();
+        verify(ghPullRequest, times(1)).listCommits();
 //        verify(ghPullRequest, times(1)).getCommentsCount();
         verifyNoMoreInteractions(ghPullRequest);
 
@@ -200,7 +201,7 @@ public class GhprbRepositoryTest {
         verify(helper).getWhiteListTargetBranches();
         verify(helper).getBlackListTargetBranches();
         verify(helper, times(2)).isProjectDisabled();
-        verify(helper).checkSkipBuild(eq(ghPullRequest));
+        verify(helper).checkSkipBuildPhrase(eq(ghPullRequest));
         verify(helper, times(1)).getBlackListLabels();
         verify(helper, times(1)).getWhiteListLabels();
         verifyNoMoreInteractions(helper);
@@ -265,7 +266,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getCreatedAt();
         verify(ghPullRequest, times(1)).getHtmlUrl();
-        verify(ghPullRequest, times(1)).listCommits();
+        verify(ghPullRequest, times(3)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
         verify(ghPullRequest, times(1)).getId();
         verify(ghPullRequest, times(2)).getLabels();
@@ -277,7 +278,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getWhiteListTargetBranches();
         verify(helper, times(2)).getBlackListTargetBranches();
         verify(helper, times(4)).isProjectDisabled();
-        verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(2)).checkSkipBuildPhrase(eq(ghPullRequest));
         verify(helper, times(2)).getBlackListLabels();
         verify(helper, times(2)).getWhiteListLabels();
         verifyNoMoreInteractions(helper);
@@ -443,7 +444,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getCreatedAt();
         verify(ghPullRequest, times(1)).getHtmlUrl();
-        verify(ghPullRequest, times(1)).listCommits();
+        verify(ghPullRequest, times(3)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
         verify(ghPullRequest, times(1)).getId();
         verify(ghPullRequest, times(4)).getLabels();
@@ -455,7 +456,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getWhiteListTargetBranches();
         verify(helper, times(2)).getBlackListTargetBranches();
         verify(helper, times(4)).isProjectDisabled();
-        verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(2)).checkSkipBuildPhrase(eq(ghPullRequest));
         verify(helper, times(2)).getBlackListLabels();
         verify(helper, times(2)).getWhiteListLabels();
         verifyNoMoreInteractions(helper);
@@ -535,7 +536,7 @@ public class GhprbRepositoryTest {
 
         verify(ghPullRequest, times(2)).getComments();
 //        verify(ghPullRequest, times(2)).getCommentsCount();
-        verify(ghPullRequest, times(1)).listCommits();
+        verify(ghPullRequest, times(3)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
         verify(ghPullRequest, times(1)).getId();
         verify(ghPullRequest, times(2)).getLabels();
@@ -555,7 +556,7 @@ public class GhprbRepositoryTest {
         verify(helper).isRetestPhrase(eq("comment body"));
         verify(helper).isTriggerPhrase(eq("comment body"));
         verify(helper, times(4)).isProjectDisabled();
-        verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(2)).checkSkipBuildPhrase(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
@@ -637,7 +638,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).getId();
         verify(ghPullRequest, times(1)).getComments();
 //        verify(ghPullRequest, times(1)).getCommentsCount();
-        verify(ghPullRequest, times(2)).listCommits();
+        verify(ghPullRequest, times(4)).listCommits();
 
         verify(ghPullRequest, times(2)).getBody();
         verifyNoMoreInteractions(ghPullRequest);
@@ -655,7 +656,7 @@ public class GhprbRepositoryTest {
         verify(helper).isRetestPhrase(eq("test this please"));
         verify(helper).isAdmin(eq(ghUser));
         verify(helper, times(4)).isProjectDisabled();
-        verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(2)).checkSkipBuildPhrase(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -297,6 +297,7 @@ public class GhprbTestUtil {
         jsonObject.put("okToTestPhrase", "ok to test");
         jsonObject.put("retestPhrase", "retest this please");
         jsonObject.put("skipBuildPhrase", "[skip ci]");
+        jsonObject.put("blackListCommitAuthor", "[bot1 bot2]");
         jsonObject.put("cron", "0 0 31 2 0");
         jsonObject.put("useComments", "true");
         jsonObject.put("useDetailedComments", "false");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GitUser;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -127,7 +128,7 @@ public class GhprbTriggerTest {
                     }
                 }
                 
-                given(helper.checkSkipBuild(issue)).willReturn(skipPhrase);
+                given(helper.checkSkipBuildPhrase(issue)).willReturn(skipPhrase);
                 
                 shouldRun.set(pr, true);
                 checkSkip.invoke(pr);
@@ -143,6 +144,49 @@ public class GhprbTriggerTest {
 
             }
         }
+    }
+
+    @Test
+    public void testCheckSkipBuildCommitAuthor() throws Exception {
+        GHPullRequest issue = mock(GHPullRequest.class);
+        GitUser user = mock(GitUser.class);
+
+        Field userNameField = GitUser.class.getDeclaredField("name");
+        userNameField.setAccessible(true);
+        userNameField.set(user, "foo");
+
+        boolean skipBuild = false;
+        boolean build = true;
+
+        Method checkSkip = GhprbPullRequest.class.getDeclaredMethod("checkSkipBuild");
+        checkSkip.setAccessible(true);
+
+        Field prField = GhprbPullRequest.class.getDeclaredField("pr");
+        prField.setAccessible(true);
+        prField.set(pr, issue);
+
+        Field commitAuthorField = GhprbPullRequest.class.getDeclaredField("commitAuthor");
+        commitAuthorField.setAccessible(true);
+        commitAuthorField.set(pr, user);
+
+        Field shouldRun = GhprbPullRequest.class.getDeclaredField("shouldRun");
+        shouldRun.setAccessible(true);
+
+        Field prHelper = GhprbPullRequest.class.getDeclaredField("helper");
+        prHelper.setAccessible(true);
+        prHelper.set(pr, helper);
+
+        given(helper.getBlacklistedCommitAuthors()).willReturn(new HashSet<String>(Arrays.asList("bot1", "bot2")));
+        given(helper.checkBlackListCommitAuthor(user.getName())).willReturn(null);
+        shouldRun.set(pr, true);
+        checkSkip.invoke(pr);
+        assertThat(shouldRun.get(pr)).isEqualTo(true);
+
+        given(helper.checkBlackListCommitAuthor(user.getName())).willReturn("bot2");
+        shouldRun.set(pr, true);
+        checkSkip.invoke(pr);
+        assertThat(shouldRun.get(pr)).isEqualTo(false);
+
     }
     
 


### PR DESCRIPTION
### Overview
GitHub PullRequest Builder provides functionality for triggering a Jenkins build on PR commit or comment from specific users. There is a specific use case when commits are made by build bots (checking in build artifacts into PullRequest as a result of the Jenkins build job). In such cases, under current conditions we inevitably running into a "recursive" build scenario, where each build commit will trigger a subsequent build.

### Change
Add ability to *skip build* if commits are made by users indicated in `Skip Build Commit Author` list configuration (see screen shot)

![image](https://cloud.githubusercontent.com/assets/324803/23249858/44227654-f95b-11e6-81b8-27acca5ebd43.png)

#### Log
```
Feb 23, 2017 4:51:41 PM org.jenkinsci.plugins.ghprb.GhprbRootAction handleAction
INFO: Checking issue comment 'test this please' for repo MyOrg/MyProject
Feb 23, 2017 4:51:41 PM org.jenkinsci.plugins.ghprb.GhprbTrigger handleComment
INFO: Checking comment on PR #1 for job myproject-build
Feb 23, 2017 4:51:41 PM org.jenkinsci.plugins.ghprb.GhprbPullRequest updatePR
INFO: Pull request #1 was updated/initialized on MyOrg/MyProject at 2/23/17 4:51 PM by Illya Chekrygin (comment)


Feb 23, 2017 4:56:29 PM hudson.model.Run execute
INFO: myproject-build #17 main build action completed: SUCCESS
Feb 23, 2017 4:56:33 PM org.jenkinsci.plugins.ghprb.GhprbRootAction handleAction
INFO: Checking PR #1 for MyOrg/MyProject
Feb 23, 2017 4:56:33 PM org.jenkinsci.plugins.ghprb.GhprbTrigger handlePR
INFO: Checking PR #1 for job myproject-build
Feb 23, 2017 4:56:33 PM org.jenkinsci.plugins.ghprb.GhprbPullRequest updatePR
INFO: Pull request #1 was updated/initialized on MyOrg/MyProject at 2/23/17 4:56 PM by Illya Chekrygin (PR update)
Feb 23, 2017 4:56:34 PM org.jenkinsci.plugins.ghprb.GhprbPullRequest checkSkipBuild
INFO: Pull request triggered by Jenkins user. Hence skipping the build.
```

### Tracking
https://github.com/jenkinsci/ghprb-plugin/issues/487
