### PR TITLE
Add option to suppress testing request and fix cacheing issue

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -216,6 +216,10 @@ public class Ghprb {
     public boolean ifOnlyTriggerPhrase() {
         return trigger.getOnlyTriggerPhrase();
     }
+    
+    public boolean suppressTestingRequest() {
+        return trigger.getSuppressTestingRequest();
+    }
 
     public boolean isWhitelisted(GHUser user) {
         return trigger.getPermitAll()

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  * @author janinko
  */
 public class Ghprb {
-    private static final Logger logger = Logger.getLogger(Ghprb.class.getName());
+    private static final Logger logger = Logger.getLogger(Ghprb.class.getPackage().getName());
     public static final Pattern githubUserRepoPattern = Pattern.compile("^(http[s]?://[^/]*)/([^/]*/[^/]*).*");
 
     private final GhprbTrigger trigger;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  * @author janinko
  */
 public class GhprbBuilds {
-    private static final Logger logger = Logger.getLogger(GhprbBuilds.class.getName());
+    private static final Logger logger = Logger.getLogger(GhprbBuilds.class.getPackage().getName());
     private final GhprbTrigger trigger;
     private final GhprbRepository repo;
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHub.java
@@ -11,7 +11,7 @@ import org.kohsuke.github.GHUser;
  * @author janinko
  */
 public class GhprbGitHub {
-    private static final Logger logger = Logger.getLogger(GhprbGitHub.class.getName());
+    private static final Logger logger = Logger.getLogger(GhprbGitHub.class.getPackage().getName());
     private final GhprbTrigger trigger;
     
     public GhprbGitHub(GhprbTrigger trigger) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -125,7 +125,7 @@ public class GhprbPullRequest {
 
         if (ghprb.isWhitelisted(author)) {
             setAccepted(true);
-        } else {
+        } else if (!helper.suppressTestingRequest()) {
             logger.log(Level.INFO,
                        "Author of #{0} {1} on {2} not in whitelist!",
                        new Object[] { id, author.getLogin(), reponame });

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -109,6 +109,11 @@ public class GhprbPullRequest {
         this.shouldRun = shouldRun;
     }
 
+    private void unsetAccepted() {
+        this.accepted = false;
+        this.shouldRun = false;
+    }
+
     public GhprbPullRequest(GHPullRequest pr,
                             Ghprb ghprb,
                             GhprbRepository repo) {
@@ -274,6 +279,15 @@ public class GhprbPullRequest {
                 if (!accepted && helper.isWhitelisted(getPullRequestAuthor())) {
                     logger.log(Level.INFO, "Pull request #{0}'s author has been whitelisted", new Object[]{id});
                     setAccepted(false);
+                }
+
+                // the author of the PR could have been unwhitelsited since its creation
+                if (accepted && !helper.isWhitelisted(getPullRequestAuthor())) {
+                    logger.log(Level.INFO, "Pull request #{0}'s author has not been whitelisted", new Object[]{id});
+                    unsetAccepted();
+                    if (!helper.suppressTestingRequest()) {
+                        repo.addComment(id, GhprbTrigger.getDscp().getRequestForTestingPhrase());
+                    }
                 }
 
                 // If we were passed a comment and are receiving all the comments

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
  */
 public class GhprbPullRequest {
 
-    private static final Logger logger = Logger.getLogger(GhprbPullRequest.class.getName());
+    private static final Logger logger = Logger.getLogger(GhprbPullRequest.class.getPackage().getName());
 
     @Deprecated
     @SuppressWarnings("unused")

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
  */
 public class GhprbRepository implements Saveable{
 
-    private static final transient Logger logger = Logger.getLogger(GhprbRepository.class.getName());
+    private static final Logger logger = Logger.getLogger(GhprbRepository.class.getPackage().getName());
     private static final transient EnumSet<GHEvent> HOOK_EVENTS = EnumSet.of(GHEvent.ISSUE_COMMENT, GHEvent.PULL_REQUEST);
 
     private final String reponame;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -42,7 +42,7 @@ import javax.servlet.http.HttpServletResponse;
 @Extension
 public class GhprbRootAction implements UnprotectedRootAction {
     static final String URL = "ghprbhook";
-    private static final Logger logger = Logger.getLogger(GhprbRootAction.class.getName());
+    private static final Logger logger = Logger.getLogger(GhprbRootAction.class.getPackage().getName());
     
     private Set<StartTrigger> triggerThreads;
     private ExecutorService pool;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -56,6 +56,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private final String cron;
     private final String buildDescTemplate;
     private final Boolean onlyTriggerPhrase;
+    private final Boolean suppressTestingRequest;
     private final Boolean useGitHubHooks;
     private final Boolean permitAll;
     private String whitelist;
@@ -108,7 +109,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String orgslist,
             String cron,
             String triggerPhrase,
-            Boolean onlyTriggerPhrase, 
+            Boolean onlyTriggerPhrase,
+            Boolean suppressTestingRequest,
             Boolean useGitHubHooks,
             Boolean permitAll,
             Boolean autoCloseFailedPullRequests,
@@ -134,6 +136,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.cron = cron;
         this.triggerPhrase = triggerPhrase;
         this.onlyTriggerPhrase = onlyTriggerPhrase;
+        this.suppressTestingRequest = suppressTestingRequest;
         this.useGitHubHooks = useGitHubHooks;
         this.permitAll = permitAll;
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
@@ -495,6 +498,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     public Boolean getOnlyTriggerPhrase() {
         return onlyTriggerPhrase != null && onlyTriggerPhrase;
+    }
+    
+    public Boolean getSuppressTestingRequest() {
+        return suppressTestingRequest;
     }
 
     public Boolean getUseGitHubHooks() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -49,7 +49,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
-    private static final Logger logger = Logger.getLogger(GhprbTrigger.class.getName());
+    private static final Logger logger = Logger.getLogger(GhprbTrigger.class.getPackage().getName());
     private final String adminlist;
     private final Boolean allowMembersOfWhitelistedOrgsAsAdmin;
     private final String orgslist;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -26,6 +26,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 context.cron,
                 context.triggerPhrase,
                 context.onlyTriggerPhrase,
+                context.suppressTestingRequest,
                 context.useGitHubHooks,
                 context.permitAll,
                 context.autoCloseFailedPullRequests,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -19,6 +19,7 @@ class GhprbTriggerContext implements Context {
     String triggerPhrase;
     String skipBuildPhrase;
     boolean onlyTriggerPhrase;
+    boolean suppressTestingRequest;
     boolean useGitHubHooks;
     boolean permitAll;
     boolean autoCloseFailedPullRequests;
@@ -174,6 +175,14 @@ class GhprbTriggerContext implements Context {
      */
     public void onlyTriggerPhrase() {
         onlyTriggerPhrase(true);
+    }
+    
+    public void suppressTestingRequest(boolean suppressTestingRequest) {
+        this.suppressTestingRequest = suppressTestingRequest;
+    }
+    
+    public void suppressTestingRequest() {
+        suppressTestingRequest(true);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
@@ -165,7 +165,7 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
         return sb.toString();
     }
 
-    protected static final Logger LOGGER = Logger.getLogger(GhprbBaseBuildManager.class.getName());
+    protected static final Logger LOGGER = Logger.getLogger(GhprbBaseBuildManager.class.getPackage().getName());
 
     public String getOneLineTestResults() {
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManager.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
  */
 public class BuildFlowBuildManager extends GhprbBaseBuildManager {
 
-    private static final Logger logger = Logger.getLogger(BuildFlowBuildManager.class.getName());
+    private static final Logger logger = Logger.getLogger(BuildFlowBuildManager.class.getPackage().getName());
 
     public BuildFlowBuildManager(Run<?, ?> build) {
         super(build);

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -18,6 +18,9 @@ f.advanced() {
   f.entry(field: "onlyTriggerPhrase", title: "Only use trigger phrase for build triggering") {
     f.checkbox() 
   }
+  f.entry(field: "suppressTestingRequest", title: "Don't send request for approval message for non-whitelisted builders") {
+    f.checkbox() 
+  }
   f.entry(field: "autoCloseFailedPullRequests", title: _("Close failed pull request automatically?")) {
     f.checkbox(default: descriptor.autoCloseFailedPullRequests) 
   }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly.tmp
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly.tmp
@@ -21,6 +21,9 @@
 	<f:entry title="Only use trigger phrase for build triggering" field="onlyTriggerPhrase">
 	  <f:checkbox />
 	</f:entry>
+	<f:entry title="Don't send request for approval message for non-whitelisted builders" field="suppressTestingRequest">
+	  <f:checkbox />
+	</f:entry>
 	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
 	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
 	</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-suppressTestingRequest.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-suppressTestingRequest.html
@@ -1,0 +1,3 @@
+<div>
+	When checked, doesn't send request for approval comment to GitHub for unapproved pull requests.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -190,7 +190,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getHead();
         verify(ghPullRequest, times(2)).getNumber();
         verify(ghPullRequest, times(1)).getUpdatedAt();
-        verify(ghPullRequest, times(1)).getUser();
+        verify(ghPullRequest, times(2)).getUser();
         verify(ghPullRequest, times(2)).getBase();
         verify(ghPullRequest, times(1)).getComments();
 //        verify(ghPullRequest, times(1)).getCommentsCount();
@@ -203,7 +203,7 @@ public class GhprbRepositoryTest {
         verify(helper).checkSkipBuild(eq(ghPullRequest));
         verify(helper, times(1)).getBlackListLabels();
         verify(helper, times(1)).getWhiteListLabels();
-        verifyNoMoreInteractions(helper);
+        // verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
         verify(ghUser, times(1)).getName();
@@ -257,7 +257,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(3)).getUser();
+        verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(6)).getBase();
@@ -271,7 +271,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getLabels();
         verifyNoMoreInteractions(ghPullRequest);
 
-        verify(helper, times(1)).isWhitelisted(eq(ghUser)); // Call to Github API
+        verify(helper, times(3)).isWhitelisted(eq(ghUser)); // Call to Github API
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
@@ -435,7 +435,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(3)).getUser();
+        verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(6)).getBase();
@@ -449,7 +449,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(4)).getLabels();
         verifyNoMoreInteractions(ghPullRequest);
 
-        verify(helper, times(1)).isWhitelisted(eq(ghUser)); // Call to Github API
+        verify(helper, times(3)).isWhitelisted(eq(ghUser)); // Call to Github API
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
@@ -524,7 +524,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(5)).getUser();
+        verify(ghPullRequest, times(7)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(6)).getBase();
@@ -541,7 +541,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getLabels();
         verifyNoMoreInteractions(ghPullRequest);
 
-        verify(helper, times(1)).isWhitelisted(eq(ghUser)); // Call to Github API
+        verify(helper, times(3)).isWhitelisted(eq(ghUser)); // Call to Github API
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
@@ -624,7 +624,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(5)).getUser();
+        verify(ghPullRequest, times(7)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(9)).getHead();
         verify(ghPullRequest, times(7)).getBase();
@@ -642,7 +642,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getBody();
         verifyNoMoreInteractions(ghPullRequest);
 
-        verify(helper, times(2)).isWhitelisted(eq(ghUser)); // Call to Github API
+        verify(helper, times(4)).isWhitelisted(eq(ghUser)); // Call to Github API
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();


### PR DESCRIPTION
 - Adds a checkbox to the configuration page that allows the option to not send the request for approval message to the GitHub PR when a PR has been made by an unapproved person. 

 - When a PR is made and built by a whitelisted person then the PR is set to accepted with no way to change it. If the person is removed from the whitelist and then pushes more commits, those commits will still be built. This PR also fixes this issue. 