### PR TITLE
Remove dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Handle 64-bit commit status id with github-api 1.90
 * Remove the hard dependency on Jenkins 2.68
 * Disable register hooks on startup via property
+* Remove ssh-agent dependency (#520)
 
 #### -> 1.39.0
 * Startup optimization. Startup for ghprb will be split into a pool size of 5 threads, which

--- a/pom.xml
+++ b/pom.xml
@@ -138,11 +138,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>ssh-agent</artifactId>
-            <version>1.15</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
             <version>1.63</version>
             <optional>true</optional>


### PR DESCRIPTION
Looking through the reflog & compile dependencies, this dependency is not needed.

It has a dependency on bouncy-castle, which can get complicated. We're removing
unnecessary complexity with this change.