### PR TITLE
[readme] optimize fetching by only fetch the needed PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ For more details, see https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+re
 * Select Git SCM.
 * Add your GitHub ``Repository URL``.
 * Under Advanced, set ``Name`` to ``origin`` and:
-  * If you **just** want to build PRs, set ``refspec`` to ``+refs/pull/*:refs/remotes/origin/pr/*``
-  * If you want to build PRs **and** branches, set ``refspec`` to ``+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*`` (see note below about [parameterized builds](#parameterized-builds))
+  * If you **just** want to build PRs, set ``refspec`` to ``+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*``
+  * If you want to build PRs **and** branches, set ``refspec`` to ``+refs/heads/*:refs/remotes/origin/* +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*`` (see note below about [parameterized builds](#parameterized-builds))
 * In ``Branch Specifier``, enter ``${sha1}`` instead of the default ``*/master``.
 * If you want to use the actual commit in the pull request, use ``${ghprbActualCommit}`` instead of ``${sha1}``
 * Under ``Build Triggers``, check ``GitHub Pull Request Builder``.


### PR DESCRIPTION
Only fetch the pull request needed for the job.
We ([Team Kodi](https://github.com/xbmc)) have 11701 pull request in https://github.com/xbmc/xbmc and the inital fetching of the repos needs some time.