### PR TITLE
Allow users to prevent webhook check/creation on Jenkins boot

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -5,6 +5,7 @@ import com.coravy.hudson.plugins.github.GithubProjectProperty;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.Util;
+import hudson.init.InitMilestone;
 import hudson.matrix.MatrixProject;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
@@ -18,7 +19,6 @@ import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.ghprb.extensions.*;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildLog;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage;
@@ -57,6 +57,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private final String buildDescTemplate;
     private final Boolean onlyTriggerPhrase;
     private final Boolean useGitHubHooks;
+    private final Boolean manageWebhooksOnStartup;
     private final Boolean permitAll;
     private String whitelist;
     private Boolean autoCloseFailedPullRequests;
@@ -110,6 +111,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String triggerPhrase,
             Boolean onlyTriggerPhrase, 
             Boolean useGitHubHooks,
+            Boolean manageWebhooksOnStartup,
             Boolean permitAll,
             Boolean autoCloseFailedPullRequests,
             Boolean displayBuildErrorsOnDownstreamBuilds,
@@ -135,6 +137,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.triggerPhrase = triggerPhrase;
         this.onlyTriggerPhrase = onlyTriggerPhrase;
         this.useGitHubHooks = useGitHubHooks;
+        this.manageWebhooksOnStartup = manageWebhooksOnStartup;
         this.permitAll = permitAll;
         this.autoCloseFailedPullRequests = autoCloseFailedPullRequests;
         this.displayBuildErrorsOnDownstreamBuilds = displayBuildErrorsOnDownstreamBuilds;
@@ -215,42 +218,71 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.ghprbGitHub = new GhprbGitHub(this);
     }
     
-
     @Override
     public void start(Job<?, ?> project, boolean newInstance) {
         // We should always start the trigger, and handle cases where we don't run in the run function.
         super.start(project, newInstance);
-        
+
         String name = project.getFullName();
 
         if (!project.isBuildable()) {
-            logger.log(Level.FINE, "Project is disabled, not starting trigger for job " + name);
+            logger.log(Level.FINE, "Project is disabled, not starting trigger for job {0}", name);
             return;
         }
         if (project.getProperty(GithubProjectProperty.class) == null) {
-            logger.log(Level.INFO, "GitHub project property is missing the URL, cannot start ghprb trigger for job " + name);
+            logger.log(Level.INFO, "GitHub project property is missing the URL, cannot start ghprb trigger for job {0}", name);
             return;
         }
         try {
             initState();
-        } catch (Exception ex) {
+        } catch (IOException ex) {
             logger.log(Level.SEVERE, "Can't start ghprb trigger", ex);
             return;
         }
 
-        logger.log(Level.INFO, "Starting the ghprb trigger for the {0} job; newInstance is {1}", 
-                new String[] { name, String.valueOf(newInstance) });
+        logger.log(Level.INFO, "Starting the ghprb trigger for the {0} job; newInstance is {1}",
+                new String[]{name, String.valueOf(newInstance)});
 
         helper = new Ghprb(this);
 
         if (getUseGitHubHooks()) {
             if (GhprbTrigger.getDscp().getManageWebhooks()) {
-                this.repository.createHook();
+                // always attempt to create the hook when Jenkins is already
+                // up and running
+                if (jenkinsHasBooted()) {
+                    logger.log(
+                            Level.INFO,
+                            "Jenkins already running; checking for webhooks for {0} job.",
+                            name
+                    );
+                    this.repository.createHook();
+                }
+                else if (getManageWebhooksOnStartup()) {
+                    logger.log(
+                            Level.INFO,
+                            "ManageWebhooksOnStartup = true; checking for webhooks for {0} job.",
+                            name
+                    );
+                    this.repository.createHook();
+                }
+                else {
+                    logger.log(
+                            Level.INFO,
+                            "ManageWebhooksOnStartup = false; not checking for webhooks for {0} job on startup.",
+                            name
+                    );
+                }
             }
+
             DESCRIPTOR.addRepoTrigger(getRepository().getName(), super.job);
         }
     }
-    
+
+    protected Boolean jenkinsHasBooted() {
+        final Jenkins instance = Jenkins.getInstance();
+        InitMilestone currentState = instance.getInitLevel();
+        return currentState != null && currentState != InitMilestone.EXTENSIONS_AUGMENTED;
+    }
 
     @Override
     public void stop() {
@@ -495,6 +527,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     public Boolean getOnlyTriggerPhrase() {
         return onlyTriggerPhrase != null && onlyTriggerPhrase;
+    }
+
+    public Boolean getManageWebhooksOnStartup() {
+        return manageWebhooksOnStartup != null && manageWebhooksOnStartup;
     }
 
     public Boolean getUseGitHubHooks() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -27,6 +27,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 context.triggerPhrase,
                 context.onlyTriggerPhrase,
                 context.useGitHubHooks,
+                context.manageWebhooksOnStartup,
                 context.permitAll,
                 context.autoCloseFailedPullRequests,
                 context.displayBuildErrorsOnDownstreamBuilds,

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -20,6 +20,7 @@ class GhprbTriggerContext implements Context {
     String skipBuildPhrase;
     boolean onlyTriggerPhrase;
     boolean useGitHubHooks;
+    boolean manageWebhooksOnStartup;
     boolean permitAll;
     boolean autoCloseFailedPullRequests;
     boolean allowMembersOfWhitelistedOrgsAsAdmin;
@@ -189,7 +190,19 @@ class GhprbTriggerContext implements Context {
     public void useGitHubHooks() {
         useGitHubHooks(true);
     }
+    /**
+     * Checking this option will disable regular polling for changes in GitHub and will try to create a GitHub hook.
+     */
+    public void manageWebhooksOnStartup(boolean manageWebhooksOnStartup) {
+        this.manageWebhooksOnStartup = manageWebhooksOnStartup;
+    }
 
+    /**
+     * Checking this option will disable regular polling for changes in GitHub and will try to create a GitHub hook.
+     */
+    public void manageWebhooksOnStartup() {
+        manageWebhooksOnStartup(true);
+    }
     /**
      * Build every pull request automatically without asking.
      */

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -9,6 +9,9 @@ f.section(title: descriptor.displayName) {
   f.entry(field: "manageWebhooks", title: _("Auto-manage webhooks")) {
     f.checkbox(default: true) 
   }  
+  f.entry(field: "manageWebhooksOnStartup", title: _("On boot check for webhooks in github")) {
+    f.checkbox(default: true)
+  }
   f.entry(field: "useComments", title: _("Use comments to report results when updating commit status fails")) {
     f.checkbox() 
   }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-manageWebhooksOnStartup.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-manageWebhooksOnStartup.html
@@ -1,0 +1,6 @@
+<div>
+	When checked, <em>GitHub Pull Request Builder</em> will attempt to reach
+        out to GitHub for all jobs and check if webhooks are configured or not.
+        It's suggested that you turn this feature <b>off</b> when you have many
+        jobs that are configured with this plugin so that startup is faster.
+</div>


### PR DESCRIPTION
On Jenkins instances with many jobs (~2k) this plugin can make the startup process chug to ~20 minutes.

This optionally allows users to stop this behavior if they have other methods to ensure that the webhook is there.

Other things that may/will be added to this PR:

- [ ] better logging?
- [ ] add a button to force a re-sync of all jobs in global `/configure`
- [ ] more tests

This PR might also be missing some very obvious things (such as configuration management). I kind of just threw together a NetBeans IDE and started hacking away, so please forgive the incompleteness of this PR.