### PR TITLE
Make startHook not blocking jenkins startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ghprb-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
 
     <issueManagement>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -293,7 +293,7 @@ public class GhprbRepository implements Saveable{
                 config.put("url", new URL(getHookUrl()).toExternalForm());
                 config.put("insecure_ssl", "1");
                 if (!StringUtils.isEmpty(secret)) {
-                 config.put("secret",secret);
+                    config.put("secret",secret);
                 }
                 getGitHubRepo().createHook("web", config, HOOK_EVENTS, true);
                 return true;

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -6,15 +6,15 @@ import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.Util;
 import hudson.matrix.MatrixProject;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
+import hudson.model.CauseAction;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Run;
 import hudson.model.Saveable;
 import hudson.model.StringParameterValue;
-import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.util.BuildData;
 import hudson.triggers.TriggerDescriptor;
@@ -26,7 +26,11 @@ import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.ghprb.extensions.*;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbBuildStep;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatus;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbGlobalDefault;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildLog;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus;
@@ -42,7 +46,12 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -75,17 +84,18 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private String skipBuildPhrase;
     private String blackListCommitAuthor;
     private String blackListLabels;
-    private String whiteListLabels;
+    private String whiteListLabels;    
     private String includedRegions;
     private String excludedRegions;
+
 
     private transient Ghprb helper;
     private transient GhprbRepository repository;
     private transient GhprbBuilds builds;
     private transient GhprbGitHub ghprbGitHub;
-    
+
     private DescribableList<GhprbExtension, GhprbExtensionDescriptor> extensions = new DescribableList<GhprbExtension, GhprbExtensionDescriptor>(Saveable.NOOP);
-    
+
     public DescribableList<GhprbExtension, GhprbExtensionDescriptor> getExtensions() {
         if (extensions == null) {
             extensions = new DescribableList<GhprbExtension, GhprbExtensionDescriptor>(Saveable.NOOP,Util.fixNull(extensions));
@@ -93,16 +103,16 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         return extensions;
     }
-    
+
     private void setExtensions(List<GhprbExtension> extensions) {
         DescribableList<GhprbExtension, GhprbExtensionDescriptor> rawList = new DescribableList<GhprbExtension, GhprbExtensionDescriptor>(
                 Saveable.NOOP,Util.fixNull(extensions));
-        
+
         // Filter out items that we only want one of, like the status updater.
-        this.extensions = Ghprb.onlyOneEntry(rawList, 
+        this.extensions = Ghprb.onlyOneEntry(rawList,
                                               GhprbCommitStatus.class
                                             );
-        
+
         // Make sure we have at least one of the types we need one of.
         for (GhprbExtension ext : getDescriptor().getExtensions()) {
             if (ext instanceof GhprbGlobalDefault) {
@@ -117,7 +127,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String orgslist,
             String cron,
             String triggerPhrase,
-            Boolean onlyTriggerPhrase, 
+            Boolean onlyTriggerPhrase,
             Boolean useGitHubHooks,
             Boolean permitAll,
             Boolean autoCloseFailedPullRequests,
@@ -127,9 +137,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String blackListCommitAuthor,
             List<GhprbBranch> whiteListTargetBranches,
             List<GhprbBranch> blackListTargetBranches,
-            Boolean allowMembersOfWhitelistedOrgsAsAdmin, 
-            String msgSuccess, 
-            String msgFailure, 
+            Boolean allowMembersOfWhitelistedOrgsAsAdmin,
+            String msgSuccess,
+            String msgFailure,
             String commitStatusContext,
             String gitHubAuthId,
             String buildDescTemplate,
@@ -171,8 +181,6 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         checkGitHubApiAuth();
         return this;
     }
-    
-
 
     @SuppressWarnings("deprecation")
     private void checkGitHubApiAuth() {
@@ -181,7 +189,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             gitHubApiAuth = null;
         }
     }
-    
+
     public static DescriptorImpl getDscp() {
         return DESCRIPTOR;
     }
@@ -202,7 +210,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         this.repository = new GhprbRepository(reponame, this);
         this.repository.load();
-        
+
         Map<Integer, GhprbPullRequest> pulls = this.pullRequests;
         this.pullRequests = null;
 
@@ -219,7 +227,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Unable to transfer map of pull requests", e);
         }
-        
+
         if (pulls != null) {
             this.repository.addPullRequests(pulls);
             this.repository.save();
@@ -229,13 +237,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.repository.init();
         this.ghprbGitHub = new GhprbGitHub(this);
     }
-    
+
 
     @Override
     public void start(Job<?, ?> project, boolean newInstance) {
         // We should always start the trigger, and handle cases where we don't run in the run function.
         super.start(project, newInstance);
-        
+
         String name = project.getFullName();
 
         if (!project.isBuildable()) {
@@ -253,7 +261,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             return;
         }
 
-        logger.log(Level.INFO, "Starting the ghprb trigger for the {0} job; newInstance is {1}", 
+        logger.log(Level.INFO, "Starting the ghprb trigger for the {0} job; newInstance is {1}",
                 new String[] { name, String.valueOf(newInstance) });
 
         helper = new Ghprb(this);
@@ -265,7 +273,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             DESCRIPTOR.addRepoTrigger(getRepository().getName(), super.job);
         }
     }
-    
+
 
     @Override
     public void stop() {
@@ -293,10 +301,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
 
         logger.log(Level.FINE, "Running trigger for {0}", super.job.getFullName());
-        
+
         this.repository.check();
     }
-    
 
     public QueueTaskFuture<?> scheduleBuild(GhprbCause cause, GhprbRepository repo) {
 
@@ -309,17 +316,16 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         } catch(Exception e) {
             logger.log(Level.SEVERE, "Unable to execute extentions for scheduleBuild", e);
         }
-        
 
         ArrayList<ParameterValue> values = getDefaultParameters();
-        
+
         final String commitSha = cause.isMerged() ? "origin/pr/" + cause.getPullID() + "/merge" : cause.getCommit();
         values.add(new StringParameterValue("sha1", commitSha));
         values.add(new StringParameterValue("ghprbActualCommit", cause.getCommit()));
         String triggerAuthor = "";
         String triggerAuthorEmail = "";
         String triggerAuthorLogin = "";
-        
+
         GhprbPullRequest pr = getRepository().getPullRequest(cause.getPullID());
         String lastBuildId = pr.getLastBuildId();
         BuildData buildData = null;
@@ -353,19 +359,19 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         values.add(new StringParameterValue("ghprbTargetBranch", String.valueOf(cause.getTargetBranch())));
         values.add(new StringParameterValue("ghprbSourceBranch", String.valueOf(cause.getSourceBranch())));
         values.add(new StringParameterValue("GIT_BRANCH", String.valueOf(cause.getSourceBranch())));
-        
+
         // it's possible the GHUser doesn't have an associated email address
         values.add(new StringParameterValue("ghprbPullAuthorEmail", getString(cause.getAuthorEmail(), "")));
         values.add(new StringParameterValue("ghprbPullAuthorLogin", String.valueOf(cause.getPullRequestAuthor().getLogin())));
         values.add(new StringParameterValue("ghprbPullAuthorLoginMention", "@" + cause.getPullRequestAuthor().getLogin()));
-        
+
         values.add(new StringParameterValue("ghprbPullDescription", escapeText(String.valueOf(cause.getShortDescription()))));
         values.add(new StringParameterValue("ghprbPullTitle", escapeText(String.valueOf(cause.getTitle()))));
         values.add(new StringParameterValue("ghprbPullLink", String.valueOf(cause.getUrl())));
         values.add(new StringParameterValue("ghprbPullLongDescription", escapeText(String.valueOf(cause.getDescription()))));
-        
+
         values.add(new StringParameterValue("ghprbCommentBody", escapeText(String.valueOf(cause.getCommentBody()))));
-        
+
         values.add(new StringParameterValue("ghprbGhRepository", getString(cause.getRepositoryName(), "")));
         values.add(new StringParameterValue("ghprbCredentialsId", getString(cause.getCredentialsId(), "")));
 
@@ -397,7 +403,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private String escapeText(String text) {
         return text.replace("\n", "\\n").replace("\r", "\\r").replace("\"", "\\\"");
     }
-    
+
     private ArrayList<ParameterValue> getDefaultParameters() {
         ArrayList<ParameterValue> values = new ArrayList<ParameterValue>();
         ParametersDefinitionProperty pdp = this.job.getProperty(ParametersDefinitionProperty.class);
@@ -416,7 +422,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     public String getGitHubAuthId() {
         return gitHubAuthId == null ? "" : gitHubAuthId;
     }
-    
+
     public GhprbGitHubAuth getGitHubApiAuth() {
         if (gitHubAuthId == null) {
             for (GhprbGitHubAuth auth: getDescriptor().getGithubAuth()){
@@ -427,13 +433,12 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         return getDescriptor().getGitHubAuth(gitHubAuthId);
     }
-    
 
     public GitHub getGitHub() throws IOException {
         GhprbGitHubAuth auth = getGitHubApiAuth();
         return auth.getConnection(getActualProject());
     }
-    
+
     public Job<?, ?> getActualProject() {
         return super.job;
     }
@@ -445,7 +450,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             logger.log(Level.SEVERE, "Failed to save new whitelist", ex);
         }
     }
-    
+
     public String getBuildDescTemplate() {
         return buildDescTemplate == null ? "" : buildDescTemplate;
     }
@@ -523,7 +528,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     public Boolean getUseGitHubHooks() {
         return useGitHubHooks != null && useGitHubHooks;
     }
-    
+
     public Ghprb getHelper() {
         if (helper == null) {
             helper = new Ghprb(this);
@@ -552,7 +557,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     }
 
     private List<GhprbBranch> normalizeTargetBranches(List<GhprbBranch> branches) {
-        if (branches == null || 
+        if (branches == null ||
                 (branches.size() == 1 && branches.get(0).getBranch().equals(""))) {
             return new ArrayList<GhprbBranch>();
         } else {
@@ -598,7 +603,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         return this.builds;
     }
-    
+
     public GhprbGitHub getGhprbGitHub() {
         if (this.ghprbGitHub == null && this.isActive()) {
             this.ghprbGitHub = new GhprbGitHub(this);
@@ -619,10 +624,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             logger.log(Level.SEVERE, "The ghprb trigger for {0} wasn''t properly started - repository is null", name);
             isActive = false;
         }
-        
+
         return isActive;
     }
-    
+
     public GhprbRepository getRepository() {
         if (this.repository == null && super.job != null  && super.job.isBuildable()) {
             try {
@@ -633,12 +638,11 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         }
         return this.repository;
     }
-    
+
     public String getProjectName() {
         String projectName = super.job == null ? "NOT_STARTED" : super.job.getFullName();
         return projectName;
     }
-    
 
     public boolean matchSignature(String body, String signature) {
         if (!isActive()) {
@@ -647,10 +651,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         GhprbGitHubAuth auth = getGitHubApiAuth();
         return auth == null ? false : auth.checkSignature(body, signature);
     }
-    
+
     public void handleComment(IssueComment issueComment) throws IOException {
         GhprbRepository repo = getRepository();
-        
+
         logger.log(Level.INFO, "Checking comment on PR #{0} for job {1}", new Object[] {issueComment.getIssue().getNumber(), getProjectName()});
 
         repo.onIssueCommentHook(issueComment);
@@ -667,13 +671,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     public static final class DescriptorImpl extends TriggerDescriptor {
         // GitHub username may only contain alphanumeric characters or dashes and cannot begin with a dash
         private static final Pattern adminlistPattern = Pattern.compile("((\\p{Alnum}[\\p{Alnum}-]*)|\\s)*");
-        
+
         private Integer configVersion;
 
         /**
-         * These settings only really affect testing. When Jenkins calls configure() then the formdata will 
+         * These settings only really affect testing. When Jenkins calls configure() then the formdata will
          * be used to replace all of these fields. Leaving them here is useful for
-         * testing, but must not be confused with a default. They also should not be used as the default 
+         * testing, but must not be confused with a default. They also should not be used as the default
          * value in the global.jelly file as this value is dynamic and will not be
          * retained once configure() is called.
          */
@@ -695,13 +699,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private String whiteListLabels;
 
         private List<GhprbGitHubAuth> githubAuth;
-        
+
         public GhprbGitHubAuth getGitHubAuth(String gitHubAuthId) {
-            
+
             if (gitHubAuthId == null) {
                 return getGithubAuth().get(0);
             }
-            
+
             GhprbGitHubAuth firstAuth = null;
             for (GhprbGitHubAuth auth : getGithubAuth()) {
                 if (firstAuth == null) {
@@ -713,7 +717,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             }
             return firstAuth;
         }
-        
+
         public List<GhprbGitHubAuth> getGithubAuth() {
             if (githubAuth == null || githubAuth.size() == 0) {
                 githubAuth = new ArrayList<GhprbGitHubAuth>(1);
@@ -721,37 +725,37 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             }
             return githubAuth;
         }
-        
+
         public List<GhprbGitHubAuth> getDefaultAuth(List<GhprbGitHubAuth> githubAuth) {
             if (githubAuth != null && githubAuth.size() > 0) {
                 return githubAuth;
             }
             return getGithubAuth();
         }
-        
+
         private String adminlist;
-        
+
         private String requestForTestingPhrase;
 
         // map of jobs (by their fullName) and their map of pull requests
         private transient Map<String, Map<Integer, GhprbPullRequest>> jobs;
-        
+
         /**
          *  map of jobs (by the repo name);  No need to keep the projects from shutdown to startup.
          *  New triggers will register here, and ones that are stopping will remove themselves.
          */
         private transient Map<String, Set<Job<?, ?>>> repoJobs;
-        
+
         public List<GhprbExtensionDescriptor> getExtensionDescriptors() {
             return GhprbExtensionDescriptor.allProject();
         }
-        
+
         public List<GhprbExtensionDescriptor> getGlobalExtensionDescriptors() {
             return GhprbExtensionDescriptor.allGlobal();
         }
-        
+
         private DescribableList<GhprbExtension, GhprbExtensionDescriptor> extensions;
-        
+
         public DescribableList<GhprbExtension, GhprbExtensionDescriptor> getExtensions() {
             if (extensions == null) {
                 extensions = new DescribableList<GhprbExtension, GhprbExtensionDescriptor>(Saveable.NOOP);
@@ -767,16 +771,16 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             }
             saveAfterPause();
         }
-        
+
         private void saveAfterPause() {
-            new java.util.Timer().schedule( 
+            new java.util.Timer().schedule(
                                            new java.util.TimerTask() {
                                                @Override
                                                public void run() {
                                                    save();
                                                }
-                                           }, 
-                                           5000 
+                                           },
+                                           5000
                                    );
         }
 
@@ -808,9 +812,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             displayBuildErrorsOnDownstreamBuilds = formData.getBoolean("displayBuildErrorsOnDownstreamBuilds");
             blackListLabels = formData.getString("blackListLabels");
             whiteListLabels = formData.getString("whiteListLabels");
-            
+
             githubAuth = req.bindJSONToList(GhprbGitHubAuth.class, formData.get("githubAuth"));
-            
+
             extensions = new DescribableList<GhprbExtension, GhprbExtensionDescriptor>(Saveable.NOOP);
 
             try {
@@ -820,13 +824,12 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            
+
             readBackFromLegacy();
 
             saveAfterPause();
             return super.configure(req, formData);
         }
-        
 
         public FormValidation doCheckAdminlist(@QueryParameter String value) throws ServletException {
             if (!adminlistPattern.matcher(value).matches()) {
@@ -835,7 +838,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             }
             return FormValidation.ok();
         }
-        
+
         public ListBoxModel doFillUnstableAsItems() {
             ListBoxModel items = new ListBoxModel();
             GHCommitState[] results = new GHCommitState[] {GHCommitState.SUCCESS,GHCommitState.ERROR,GHCommitState.FAILURE};
@@ -844,12 +847,12 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                 items.add(text, nextResult.toString());
                 if (unstableAs.toString().equals(nextResult.toString())) {
                     items.get(items.size()-1).selected = true;
-                } 
+                }
             }
 
             return items;
         }
-        
+
         public String getAdminlist() {
             return adminlist;
         }
@@ -913,7 +916,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         public GHCommitState getUnstableAs() {
             return unstableAs;
         }
-        
+
         public Integer getConfigVersion() {
             return configVersion;
         }
@@ -925,7 +928,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         public boolean isUseDetailedComments() {
             return (useDetailedComments != null && useDetailedComments);
         }
-        
+
         public ListBoxModel doFillGitHubAuthIdItems(@QueryParameter("gitHubAuthId") String gitHubAuthId) {
             ListBoxModel model = new ListBoxModel();
             for (GhprbGitHubAuth auth : getGithubAuth()) {
@@ -940,7 +943,6 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             }
             return model;
         }
-        
 
         public Map<Integer, GhprbPullRequest> getPullRequests(String projectName) {
             Map<Integer, GhprbPullRequest> ret = null;
@@ -950,13 +952,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             }
             return ret;
         }
-        
+
         private void addRepoTrigger(String repo, Job<?, ?> project) {
             if (project == null || StringUtils.isEmpty(repo)) {
                 return;
             }
             logger.log(Level.FINE, "Adding [{0}] to webhooks repo [{1}]", new Object[]{project.getFullName(), repo});
-            
+
             synchronized (this) {
                 Set<Job<?, ?>> projects = repoJobs.get(repo);
                 if (projects == null) {
@@ -966,11 +968,11 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                 } else {
                     logger.log(Level.FINE, "Adding project to current repo set, length: {0}", new Object[]{projects.size()});
                 }
-                
+
                 projects.add(project);
             }
         }
-        
+
         private void removeRepoTrigger(String repo, Job<?, ?> project) {
             Set<Job<?, ?>> projects = repoJobs.get(repo);
             if (project != null && projects != null) {
@@ -978,13 +980,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                 projects.remove(project);
             }
         }
-        
+
         public Set<Job<?, ?>> getRepoTriggers(String repo) {
             if (repoJobs == null) {
                 repoJobs = new ConcurrentHashMap<String, Set<Job<?, ?>>>(5);
             }
             logger.log(Level.FINE, "Retrieving triggers for repo [{0}]", new Object[]{repo});
-            
+
             Set<Job<?, ?>> projects = repoJobs.get(repo);
             if (projects != null) {
                 for (Job<?, ?> project : projects) {
@@ -993,14 +995,14 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             } else {
                 projects = Collections.newSetFromMap(new WeakHashMap<Job<?, ?>, Boolean>(0));
             }
-            
+
             return projects;
         }
 
         public List<GhprbBranch> getWhiteListTargetBranches() {
             return whiteListTargetBranches;
         }
-        
+
         public List<GhprbBranch> getBlackListTargetBranches() {
             return blackListTargetBranches;
         }
@@ -1023,12 +1025,12 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private transient String password;
         @Deprecated
         private transient String serverAPIUrl;
-        
+
         public void readBackFromLegacy() {
             if (configVersion == null) {
                 configVersion = 0;
             }
-            
+
             if (logExcerptLines != null && logExcerptLines > 0) {
                 addIfMissing(new GhprbBuildLog(logExcerptLines));
                 logExcerptLines = null;
@@ -1049,13 +1051,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                 }
                 addIfMissing(new GhprbBuildStatus(messages));
             }
-            
+
             if (configVersion < 1) {
                 GhprbSimpleStatus status = new GhprbSimpleStatus(commitStatusContext);
                 addIfMissing(status);
                 commitStatusContext = null;
             }
-            
+
             if (!StringUtils.isEmpty(accessToken)) {
                 try {
                     GhprbGitHubAuth auth = new GhprbGitHubAuth(serverAPIUrl, null, Ghprb.createCredentials(serverAPIUrl, accessToken), "Pre credentials Token", null, null);
@@ -1069,7 +1071,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                     e.printStackTrace();
                 }
             }
-            
+
             if (!StringUtils.isEmpty(username) || !StringUtils.isEmpty(password)) {
                 try {
                     GhprbGitHubAuth auth = new GhprbGitHubAuth(serverAPIUrl, null, Ghprb.createCredentials(serverAPIUrl, username, password), "Pre credentials username and password", null, null);
@@ -1084,17 +1086,15 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                     e.printStackTrace();
                 }
             }
-            
+
             configVersion = 1;
         }
-        
 
         private void addIfMissing(GhprbExtension ext) {
             if (getExtensions().get(ext.getClass()) == null) {
                 getExtensions().add(ext);
             }
         }
-        
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GeneralTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GeneralTest.java
@@ -1,9 +1,5 @@
 package org.jenkinsci.plugins.ghprb;
 
-import static org.fest.assertions.Assertions.assertThat;
-
-import java.util.List;
-
 import org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildLog;
 import org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage;
@@ -14,9 +10,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+
 @RunWith(MockitoJUnitRunner.class)
 public class GeneralTest {
-    
+
     private void checkClassForGetters(Class<?> clazz) {
         List<String> errors = GhprbTestUtil.checkClassForGetters(clazz);
         assertThat(errors).isEmpty();
@@ -36,12 +36,11 @@ public class GeneralTest {
     public void checkPullRequestMergeForGetters() {
         checkClassForGetters(GhprbPullRequestMerge.class);
     }
-    
+
     @Test
     public void checkBuildLogForGetters() {
         checkClassForGetters(GhprbBuildLog.class);
     }
-
 
     @Test
     public void checkBuildResultMessageForGetters() {
@@ -58,7 +57,6 @@ public class GeneralTest {
         checkClassForGetters(GhprbCommentFile.class);
     }
 
-
     @Test
     public void checkSimpleStatusForGetters() {
         checkClassForGetters(GhprbSimpleStatus.class);
@@ -68,5 +66,4 @@ public class GeneralTest {
     public void checkCancelBuildsOnUpdateForGetters() {
         checkClassForGetters(GhprbCancelBuildsOnUpdate.class);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -1,13 +1,10 @@
 package org.jenkinsci.plugins.ghprb;
 
 import com.google.common.collect.Lists;
-
-import hudson.model.*;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParameterValue;
+import hudson.model.Run;
 import net.sf.json.JSONObject;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -23,26 +20,28 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import static com.google.common.collect.Lists.newArrayList;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
-
 
 @RunWith(MockitoJUnitRunner.class)
 public class GhprbIT extends GhprbITBaseTestCase {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
-    
+
     @Mock
     private RequestImpl req;
+
     @Mock
     private GHIssueComment comment;
 
-    
     private FreeStyleProject project;
-    
 
     @Before
     public void setUp() throws Exception {// GIVEN
@@ -64,7 +63,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
     @Test
     public void shouldBuildTriggersOnNewPR() throws Exception {
         given(ghPullRequest.getNumber()).willReturn(1);
-        
+
         GhprbTestUtil.triggerRunAndWait(10, trigger, project);
 
         assertThat(project.getBuilds().toArray().length).isEqualTo(1);
@@ -109,7 +108,6 @@ public class GhprbIT extends GhprbITBaseTestCase {
     @Test
     public void shouldNotBuildDisabledBuild() throws Exception {
         // GIVEN
-        
         given(commitPointer.getSha()).willReturn("sha");
 
         given(comment.getBody()).willReturn("retest this please");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
@@ -2,12 +2,17 @@ package org.jenkinsci.plugins.ghprb;
 
 import com.coravy.hudson.plugins.github.GithubProjectProperty;
 import hudson.model.AbstractProject;
-import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitSCM;
 import org.joda.time.DateTime;
-import org.kohsuke.github.*;
+import org.kohsuke.github.GHCommitPointer;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRateLimit;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -15,7 +20,9 @@ import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 
 /**
  * @author mdelapenya (Manuel de la Peña)
@@ -47,23 +54,22 @@ public abstract class GhprbITBaseTestCase {
     protected void beforeTest(Map<String, Object> globalConfig, Map<String, Object> triggerConfig, AbstractProject<?, ?> project) throws Exception {
         project.addProperty(new GithubProjectProperty("https://github.com/user/dropwizard"));
         GhprbTestUtil.setupGhprbTriggerDescriptor(globalConfig);
-        
+
         trigger = GhprbTestUtil.getTrigger(triggerConfig);
-        
+
         GitHub gitHub = trigger.getGitHub();
-        
+
         given(gitHub.getRepository(anyString())).willReturn(ghRepository);
-        
+
         given(ghPullRequest.getHead()).willReturn(commitPointer);
         given(ghPullRequest.getUser()).willReturn(ghUser);
-        
+
         given(commitPointer.getRef()).willReturn("ref");
         given(commitPointer.getSha()).willReturn("sha");
-        
+
         given(ghRepository.getName()).willReturn("dropwizard");
 
         GhprbTestUtil.mockPR(ghPullRequest, commitPointer, new DateTime(), new DateTime().plusDays(1));
-        
 
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(newArrayList(ghPullRequest)).willReturn(newArrayList(ghPullRequest));
         given(ghRepository.getPullRequest(Mockito.anyInt())).willReturn(ghPullRequest);
@@ -74,14 +80,12 @@ public abstract class GhprbITBaseTestCase {
         ghRateLimit.remaining = GhprbTestUtil.INITIAL_RATE_LIMIT;
 
         GhprbTestUtil.mockCommitList(ghPullRequest);
-        
 
         GhprbRepository repo = Mockito.spy(new GhprbRepository("user/dropwizard", trigger));
         Mockito.doReturn(ghRepository).when(repo).getGitHubRepo();
         Mockito.doNothing().when(repo).addComment(Mockito.anyInt(), Mockito.anyString(), any(Run.class), any(TaskListener.class));
         Mockito.doReturn(ghprbPullRequest).when(repo).getPullRequest(Mockito.anyInt());
 
-        
         Mockito.doReturn(repo).when(trigger).getRepository();
 
         builds = new GhprbBuilds(trigger, repo);
@@ -91,7 +95,6 @@ public abstract class GhprbITBaseTestCase {
         given(helper.getTrigger()).willReturn(trigger);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getBuilds()).willReturn(builds);
-        
 
         Mockito.doCallRealMethod().when(trigger).run();
 


### PR DESCRIPTION
This PR is two folded. The first commits holds a lot of whitespace fixes. 

The second commit is the actually change. It moves the creating of the hook into a runnable, which makes it way faster on startup. 

I have choosen a fixed thread pool with five executors. Not sure if this is a good value or not :)