### PR TITLE
Disable register hooks on startup via property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,11 +188,6 @@
             <version>1.4</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-core</artifactId>
-            <version>2.68</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.9</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.7</version>
+        <version>2.32</version>
     </parent>
 
     <artifactId>ghprb</artifactId>
@@ -50,35 +50,101 @@
     </properties>
 
     <dependencies>
+
+        <!-- added dependencies because of maven enforcer plugin -->
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>symbol-annotation</artifactId>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>annotation-indexer</artifactId>
+            <version>1.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>9.2.15.v20160210</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>9.2.15.v20160210</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-classworlds</artifactId>
+            <version>2.4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>bouncycastle-api</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+
+        <!-- end added dependencies because of maven enforcer plugin -->
+
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.26.0</version>
+            <version>1.27.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.6</version>
+            <version>1.11</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.82</version>
+            <version>1.86</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.4.0</version>
+            <version>3.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-agent</artifactId>
-            <version>1.3</version>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.39</version>
+            <version>1.63</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -102,34 +168,34 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.10</version>
+            <version>2.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.cloudbees.plugins</groupId>
             <artifactId>build-flow-plugin</artifactId>
-            <version>0.12</version>
+            <version>0.20</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1.21</version>
+            <version>2.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.1</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-core</artifactId>
-            <version>2.1</version>
+            <version>2.68</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.6</version>
+            <version>1.9</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -11,7 +11,6 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.Util;
 import hudson.model.*;
 import hudson.security.ACL;
-import hudson.triggers.Trigger;
 import hudson.util.DescribableList;
 import hudson.util.Secret;
 import jenkins.model.ParameterizedJobMixIn;
@@ -397,7 +396,7 @@ public class Ghprb {
         ParameterizedJobMixIn.ParameterizedJob pJob = (ParameterizedJobMixIn.ParameterizedJob) p;
         GhprbTrigger ghprbTrigger = null;
         if (p instanceof ParameterizedJobMixIn.ParameterizedJob) {
-            for (Trigger trigger : pJob.getTriggers().values()) {
+            for (Object trigger : pJob.getTriggers().values()) {
                 if (trigger instanceof GhprbTrigger) {
                     ghprbTrigger = (GhprbTrigger) trigger;
                     break;


### PR DESCRIPTION
This change provides an admin the ability to better control how GhprbTrigger initializes.

- Convert existing system properties to use standards from Jenkins core.  This is necessary to sanitize user input to ensure that system properties are properly handled.  This also integrates with Jenkins system logging when a user accidentally misconfigures a property.
- Add a system property to disable registering GitHub webhooks on startup.  This assumes that hooks were already properly registered when an admin or user created the Jenkins job.
- Implements recommendations from #535

This change provides the following system properties:

- `org.jenkinsci.plugins.ghprb.GhprbTrigger.poolSize=N` where `N` is an integer defining number of threads to use for registering webhooks on startup.
- `org.jenkinsci.plugins.ghprb.GhprbTrigger.disableRegisterOnStartup=N` where `N` is boolean `true` or `false`.

Additional notes:

- Jenkins 2 is now a requirement.
- Updated all dependencies to resolve building against Jenkins 2.
- Added pinned dependencies to resolve build issues with the maven enforcer plugin.
- Added more debug logging.