### PR TITLE
Fix catastrophic backtracking regex match

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -678,7 +678,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     public static final class DescriptorImpl extends TriggerDescriptor {
         // GitHub username may only contain alphanumeric characters or dashes and cannot begin with a dash
-        private static final Pattern adminlistPattern = Pattern.compile("((\\p{Alnum}[\\p{Alnum}-]*)|\\s)*");
+        private static final Pattern adminlistPattern = Pattern.compile("(\\p{Alnum}[\\p{Alnum}-]*+|\\s)*+");
 
         private Integer configVersion;
 


### PR DESCRIPTION
`adminlistPattern` has exponential backtracking when an invalid
character is encountered, this leads to
`/job/<name>/descriptorByName/org.jenkinsci.plugins.ghprb.GhprbTrigger/checkAdminlist`
requests never returning, and leaking a java thread working at 100%
CPU.
So each load of `/job/<name>/configure` adds +100% CPU to the jenkins
process, at least when the admin list is configured globally.

This is a DoS security risk, although it requires configuration rights
for the attacker.

There is no timeout in the regex, nor at the HTTP level (possibly not
possible).

Fixed the issue using possessive quantifiers. Also removed unnecessary
`()` in alternated tokens.


Tests:
* base regex: http://fiddle.re/2kkpad (click Java, then wait 10s timeout)
* new regex: http://fiddle.re/xxet2d