### PR TITLE
Better GitHub username check

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -678,7 +678,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     public static final class DescriptorImpl extends TriggerDescriptor {
         // GitHub username may only contain alphanumeric characters or dashes and cannot begin with a dash
-        private static final Pattern adminlistPattern = Pattern.compile("(\\p{Alnum}[\\p{Alnum}-]*+|\\s)*+");
+        private static final Pattern adminlistPattern = Pattern.compile("(\\p{Alnum}(-?+\\p{Alnum})*+|\\s)*+");
 
         private Integer configVersion;
 
@@ -843,7 +843,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         public FormValidation doCheckAdminlist(@QueryParameter String value) throws ServletException {
             if (!adminlistPattern.matcher(value).matches()) {
                 return FormValidation.error("GitHub username may only contain alphanumeric characters or dashes "
-                        + "and cannot begin with a dash. Separate them with whitespaces.");
+                                            + "and cannot have multiple consecutive dashes "
+                                            + "and cannot begin or end with a dash. "
+                                            + "Separate them with whitespaces.");
             }
             return FormValidation.ok();
         }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -678,7 +678,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     public static final class DescriptorImpl extends TriggerDescriptor {
         // GitHub username may only contain alphanumeric characters or dashes and cannot begin with a dash
-        private static final Pattern adminlistPattern = Pattern.compile("((\\p{Alnum}[\\p{Alnum}-]*)|\\s)*");
+        private static final Pattern adminlistPattern = Pattern.compile("(\\p{Alnum}[\\p{Alnum}-]*+|\\s)*+");
 
         private Integer configVersion;
 


### PR DESCRIPTION
The rules are:
- Github username may only contain alphanumeric characters or hyphens.
- Github username cannot have multiple consecutive hyphens.
- Github username cannot begin or end with a hyphen.
- Maximum is 39 characters. (not implemented)

Previous implementation:
- Github username may only contain alphanumeric characters or hyphens.
- Github username cannot begin with a hyphen.

Inspired from https://github.com/shinnn/github-username-regex.
Some tests:
* before: http://fiddle.re/p6qvwd
* after: http://fiddle.re/b0m3cd


Also `adminlistPattern` has exponential backtracking when an invalid
character is encountered, this leads to
`/job/<name>/descriptorByName/org.jenkinsci.plugins.ghprb.GhprbTrigger/checkAdminlist`
requests never returning, and leaking a java thread working at 100%
CPU.
So each load of `/job/<name>/configure` adds +100% CPU to the jenkins
process, at least when the admin list is configured globally.

This is a DoS security risk, although it requires configuration rights
for the attacker.

There is no timeout in the regex, nor at the HTTP level (possibly not
possible).

Fixed the issue using possessive quantifiers. Also removed unnecessary
`()` in alternated tokens.


Tests:
* base regex: http://fiddle.re/2kkpad (click Java, then wait 10s timeout)
* new regex: http://fiddle.re/xxet2d