### PR TITLE
Handle 64-bit commit id from new github-api

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -113,3 +113,4 @@
 - ray.sennewald@gmail.com
 - rehevkor5
 - rsennewald
+- rholder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### Updates
+#### -> 1.40.0
+* Handle 64-bit commit status id with github-api 1.90
+* Remove the hard dependency on Jenkins 2.68
+* Disable register hooks on startup via property
+
 #### -> 1.39.0
 * Startup optimization. Startup for ghprb will be split into a pool size of 5 threads, which
 can be overridden via JVM args.

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.86</version>
+            <version>1.90</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -121,8 +121,12 @@ public class GhprbPullRequest {
         this.helper = ghprb;
 
         this.repo = repo;
-
-        GHUser author = pr.getUser();
+        GHUser author;
+        try {
+            author = pr.getUser();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         String reponame = repo.getName();
 
         if (ghprb.isWhitelisted(author)) {

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -138,7 +138,7 @@ public class GhprbRepositoryTest {
         given(gt.getRateLimit()).willThrow(new FileNotFoundException());
         List<GHPullRequest> ghPullRequests = createListWithMockPR();
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
 
         mockHeadAndBase();
         mockCommitList();
@@ -232,8 +232,8 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-        given(ghPullRequest.getId()).willReturn(100);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghPullRequest.getId()).willReturn(100L);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
         
         given(ghUser.getEmail()).willReturn("email");
 
@@ -316,9 +316,9 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-        given(ghPullRequest.getId()).willReturn(100);
+        given(ghPullRequest.getId()).willReturn(100L);
         given(ghPullRequest.getLabels()).willReturn(ghLabels);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
 
         given(ghUser.getEmail()).willReturn("email");
 
@@ -364,9 +364,9 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-        given(ghPullRequest.getId()).willReturn(100);
+        given(ghPullRequest.getId()).willReturn(100L);
         given(ghPullRequest.getLabels()).willReturn(ghLabels);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
 
         given(ghUser.getEmail()).willReturn("email");
 
@@ -411,9 +411,9 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-        given(ghPullRequest.getId()).willReturn(100);
+        given(ghPullRequest.getId()).willReturn(100L);
         given(ghPullRequest.getLabels()).willReturn(ghLabels);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
 
         given(ghUser.getEmail()).willReturn("email");
 
@@ -499,8 +499,8 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-        given(ghPullRequest.getId()).willReturn(100);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghPullRequest.getId()).willReturn(100L);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
         
         given(ghUser.getEmail()).willReturn("email");
         given(ghUser.getLogin()).willReturn("login");
@@ -597,8 +597,8 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getUser()).willReturn(ghUser);
         given(ghPullRequest.getHtmlUrl()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
-        given(ghPullRequest.getId()).willReturn(100);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghPullRequest.getId()).willReturn(100L);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
         
         given(ghUser.getEmail()).willReturn("email");
@@ -709,7 +709,7 @@ public class GhprbRepositoryTest {
         // GIVEN
         List<GHPullRequest> ghPullRequests = new ArrayList<GHPullRequest>();
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
-        given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghRepository.getPullRequest((int) ghPullRequest.getId())).willReturn(ghPullRequest);
 
         // WHEN
         ghprbRepository.check();

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
@@ -104,7 +104,7 @@ public class GhprbRootActionTest {
         given(commitPointer.getSha()).willReturn("sha1");
         GhprbTestUtil.setupGhprbTriggerDescriptor(null);
         project.addProperty(new GithubProjectProperty("https://github.com/user/dropwizard"));
-        given(ghPullRequest.getId()).willReturn(prId);
+        given(ghPullRequest.getId()).willReturn((long) prId);
         given(ghPullRequest.getNumber()).willReturn(prId);
         given(ghRepository.getPullRequest(prId)).willReturn(ghPullRequest);
         Ghprb ghprb = spy(new Ghprb(trigger));
@@ -170,7 +170,7 @@ public class GhprbRootActionTest {
         given(commitPointer.getSha()).willReturn("sha1");
         GhprbTestUtil.setupGhprbTriggerDescriptor(null);
         project.addProperty(new GithubProjectProperty("https://github.com/user/dropwizard"));
-        given(ghPullRequest.getId()).willReturn(prId);
+        given(ghPullRequest.getId()).willReturn((long) prId);
         given(ghPullRequest.getNumber()).willReturn(prId);
         given(ghRepository.getPullRequest(prId)).willReturn(ghPullRequest);
         Ghprb ghprb = spy(new Ghprb(trigger));


### PR DESCRIPTION
The `github-api` has been bumped up to 1.90 to roll in the fixes from jenkinsci/github-api-plugin#16. This should take care of #580 and the duplicate #587. Notable things here:
* Rethrowing of `IOException` in a `RuntimeException` to mitigate API changes from 1.90 `github-api` dependency in `GhprbPullRequest`
* Patched up tests for API changes with some quick casts
* The plugin is compiling and all tests run with `mvn clean test` are passing

If we cut a release off of this, it will include the updates from #543 that went in recently. I've added notes to the `CHANGELOG.md` to make this obvious and quicker to get to a release. Let me know if I can help speed this along, and I'll try to do what I can.