### PR TITLE
Update list of current maintainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,15 +15,22 @@
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>
 
+    <!--
+      The developers show up as current maintainers in the Jenkins wiki.
+      https://wiki.jenkins.io/display/JENKINS/GitHub+pull+request+builder+plugin
+
+      The id should be the jenkins.io username and not your GitHub username.
+    -->
     <developers>
         <developer>
-            <id>janinko</id>
-            <name>Honza Brázdil</name>
-            <email>jbrazdil@redhat.com</email>
-        </developer>
-        <developer>
-            <id>valdisrigdon</id>
-            <name>Valdis Rigdon</name>
+            <id>sag47</id>
+            <name>Sam Gleske</name>
+            <email>sam.mxracer@gmail.com</email>
+            <url>https://github.com/samrocketman</url>
+            <roles>
+                <role>maintainer</role>
+            </roles>
+            <timezone>America/Los_Angeles</timezone>
         </developer>
     </developers>
     <scm>


### PR DESCRIPTION
ref: https://wiki.jenkins.io/display/JENKINS/GitHub+pull+request+builder+plugin

The intent of this change is to reflect in Jenkins wiki metadata the current active maintainers.  This is so Jenkins users have an up to date list of points of contact for this plugin.

For now, I've removed @janinko and @valdisrigdon since I haven't seen them post in a while.  If you guys don't want to be removed, then comment in this PR and let me know you want your ID to remain.  I'll wait ~1 week before merging this for your feedback.

@jenkinsci/ghprb-plugin-developers after this change is merged I recommend you following up with PRs to add yourselves if you wish to be reflected as a point of contact in the Jenkins wiki.