### PR TITLE
Improve "Build triggered/started" messages

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -132,11 +132,11 @@ public class GhprbSimpleStatus extends GhprbExtension implements
         if (!StringUtils.isEmpty(triggeredStatus)) {
             sb.append(Ghprb.replaceMacros(project, triggeredStatus));
         } else {
-            sb.append("Build triggered.");
+            sb.append("Build triggered");
             if (isMergeable) {
-                sb.append(" sha1 is merged.");
+                sb.append(" for merge commit.");
             } else {
-                sb.append(" sha1 is original commit.");
+                sb.append(" for original commit.");
             }
         }
 
@@ -184,7 +184,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements
         if (StringUtils.isEmpty(startedStatus)) {
             sb.append("Build started");
             if (c != null) {
-                sb.append(c.isMerged() ? " sha1 is merged." : " sha1 is original commit.");
+                sb.append(c.isMerged() ? " for merge commit." : " for original commit.");
             }
         } else {
             sb.append(Ghprb.replaceMacros(build, listener, startedStatus));

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -72,7 +72,7 @@ public class GhprbRepositoryTest {
 
     private static final Date UPDATE_DATE = new Date();
 
-    private static final String MSG = "Build triggered. sha1 is merged.";
+    private static final String MSG = "Build triggered for merge commit.";
 
     @Mock
     private GHRepository ghRepository;

--- a/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
@@ -41,7 +41,7 @@ public class GhprbSimpleStatusTest {
 
     @Test
     public void testMergedMessage() throws Exception {
-        String mergedMessage = "Build triggered. sha1 is merged.";
+        String mergedMessage = "Build triggered for merge commit.";
         given(ghprbPullRequest.getHead()).willReturn("sha");
         given(ghprbPullRequest.isMergeable()).willReturn(true);
 
@@ -56,7 +56,7 @@ public class GhprbSimpleStatusTest {
 
     @Test
     public void testMergeConflictMessage() throws Exception {
-        String mergedMessage = "Build triggered. sha1 is original commit.";
+        String mergedMessage = "Build triggered for original commit.";
         given(ghprbPullRequest.getHead()).willReturn("sha");
         given(ghprbPullRequest.isMergeable()).willReturn(false);
 
@@ -71,7 +71,7 @@ public class GhprbSimpleStatusTest {
 
     @Test
     public void testDoesNotSendEmptyContext() throws Exception {
-        String mergedMessage = "Build triggered. sha1 is original commit.";
+        String mergedMessage = "Build triggered for original commit.";
         given(ghprbPullRequest.getHead()).willReturn("sha");
         given(ghprbPullRequest.isMergeable()).willReturn(false);
 


### PR DESCRIPTION
Previously, the messages were "Build triggered sha1 is {merged,original
commit}." (note the lack of full-stop after "triggered") and "Build
started. sha1 is {merged,original commit}.". Make these consistent, and
make the message clearer: "Build {triggered,started} for
{merge,original} commit."