### PR TITLE
Get rid of the explicit JTH dependency so that the tests can run more reliably in PCT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,15 +44,14 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/janinko/ghprb/issues</url>
+        <url>https://github.com/jenkinsci/ghprb/issues</url>
     </issueManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <workflow.version>1.4</workflow.version>
-        <jenkins.version>2.7</jenkins.version>
-        <jenkins-test-harness.version>2.17</jenkins-test-harness.version>
+        <jenkins.version>2.7.3</jenkins.version>
         <java.level>7</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
         <checkstyle.version>6.7</checkstyle.version>
@@ -98,6 +97,7 @@
             <artifactId>ant</artifactId>
             <version>1.9.2</version>
         </dependency>
+        <!-- TODO: why would it need to bundle Jetty at all? the version is aligned with JTH versio -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>


### PR DESCRIPTION
@reviewbybees @jglick 
