### PR TITLE
[JENKINS-48950] [JEP-200] Stop trying to serialize github-api types

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
@@ -30,13 +30,13 @@ public class GhprbCause extends Cause {
 
     private final URL url;
 
-    private final GHUser triggerSender;
+    private final transient GHUser triggerSender;
 
     private final String commentBody;
 
-    private final GitUser commitAuthor;
+    private final transient GitUser commitAuthor;
 
-    private final GHUser pullRequestAuthor;
+    private final transient GHUser pullRequestAuthor;
 
     private final String description;
 


### PR DESCRIPTION
[JENKINS-48950](https://issues.jenkins-ci.org/browse/JENKINS-48950)

Testing:

- [X] can build a PR without error (formerly failed with a JEP-200 exception)
- [X] after restart, build index page shows cause
- [X] after restart, build `api/xml` shows relevant information
- [X] after restart, build **Parameters** shows relevant information

@reviewbybees esp. @oleg-nenashev