### PR TITLE
Feature: Option to report success to PR when build is not triggered

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -326,6 +326,10 @@ public class Ghprb {
         return patterns;
     }
 
+    public boolean getReportSuccessIfNotRegion() {
+        return trigger.getReportSuccessIfNotRegion();
+    }
+
     public static String replaceMacros(Run<?, ?> build, TaskListener listener, String inputString) {
         String returnString = inputString;
         if (build != null && inputString != null) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -1,15 +1,21 @@
 package org.jenkinsci.plugins.ghprb;
 
 import com.google.common.base.Joiner;
+import hudson.model.Job;
 import hudson.model.Run;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatus;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
+import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.kohsuke.github.GHCommitPointer;
+import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHPullRequestFileDetail;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitUser;
 
@@ -511,7 +517,7 @@ public class GhprbPullRequest {
         }
     }
 
-    private void tryBuild() {
+    void tryBuild() {
         synchronized (this) {
             if (helper.isProjectDisabled()) {
                 LOGGER.log(Level.FINEST, "Project is disabled, not trying to build");
@@ -530,7 +536,7 @@ public class GhprbPullRequest {
             }
 
             if (shouldRun && !containsWatchedPaths(pr)) {
-                LOGGER.log(Level.FINEST, "Pull request contains no watched paths, skipping the build");
+                skipBuildForWatchedPaths();
                 shouldRun = false;
             }
 
@@ -688,6 +694,31 @@ public class GhprbPullRequest {
             LOGGER.log(Level.SEVERE, "Couldn't obtain mergeable status.", e);
         }
         return mergeable;
+    }
+
+    void skipBuildForWatchedPaths() {
+        if (helper.getReportSuccessIfNotRegion()) {
+            LOGGER.log(Level.FINEST, "Pull request contains no watched paths, skipping the build and reporting success.");
+            createCommitStatus(GHCommitState.SUCCESS, "Skipped, no pertinent files changed.");
+        } else {
+            LOGGER.log(Level.FINEST,
+                    "Pull request contains no watched paths, skipping the build");
+        }
+    }
+
+    public void createCommitStatus(GHCommitState state, String message) {
+        GHRepository ghRepository = repo.getGitHubRepo();
+        GhprbTrigger trigger = helper.getTrigger();
+        Job<?, ?> actualProject = trigger.getActualProject();
+        for (GhprbExtension ext : Ghprb.getJobExtensions(trigger, GhprbCommitStatus.class)) {
+            if (ext instanceof GhprbCommitStatus) {
+                try {
+                    ((GhprbCommitStatus) ext).createCommitStatus(actualProject, id, head, state, ghRepository, message);
+                } catch (GhprbCommitStatusException e) {
+                    repo.commentOnFailure(null, null, e);
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -135,6 +135,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     private String excludedRegions;
 
+    private Boolean reportSuccessIfNotRegion;
+
 
     private transient Ghprb helper;
 
@@ -198,7 +200,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                         String whiteListLabels,
                         List<GhprbExtension> extensions,
                         String includedRegions,
-                        String excludedRegions
+                        String excludedRegions,
+                        Boolean reportSuccessIfNotRegion
     ) throws ANTLRException {
         super(cron);
         this.adminlist = adminlist;
@@ -222,6 +225,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.whiteListLabels = whiteListLabels;
         this.includedRegions = includedRegions;
         this.excludedRegions = excludedRegions;
+        this.reportSuccessIfNotRegion = reportSuccessIfNotRegion;
         setExtensions(extensions);
         configVersion = LATEST_VERSION;
     }
@@ -659,6 +663,13 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             return "";
         }
         return excludedRegions;
+    }
+
+    public Boolean getReportSuccessIfNotRegion() {
+        if (reportSuccessIfNotRegion == null) {
+            return false;
+        }
+        return reportSuccessIfNotRegion;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/GhprbCommitStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/GhprbCommitStatus.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.ghprb.extensions;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHRepository;
 
 public interface GhprbCommitStatus {
@@ -14,4 +15,7 @@ public interface GhprbCommitStatus {
     void onBuildStart(Run<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException;
 
     void onBuildComplete(Run<?, ?> build, TaskListener listener, GHRepository repo) throws GhprbCommitStatusException;
+
+    void createCommitStatus(Job<?, ?> project, int prId, String commitSha, GHCommitState state, GHRepository ghRepository, String message)
+            throws GhprbCommitStatusException;
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbNoCommitStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbNoCommitStatus.java
@@ -9,6 +9,7 @@ import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbProjectExtension;
+import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -40,6 +41,12 @@ public class GhprbNoCommitStatus extends GhprbExtension implements GhprbCommitSt
             int prId,
             GHRepository ghRepository
     ) throws GhprbCommitStatusException {
+
+    }
+
+    public void createCommitStatus(
+            Job<?, ?> project, int prId, String commitSha, GHCommitState state, GHRepository ghRepository, String message)
+            throws GhprbCommitStatusException {
 
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -123,14 +123,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
             return;
         }
 
-        String statusUrl = getDescriptor().getStatusUrlDefault(this);
-        if (commitStatusContext == "") {
-            commitStatusContext = getDescriptor().getCommitStatusContextDefault(this);
-        }
-
-        String context = Util.fixEmpty(commitStatusContext);
-        context = Ghprb.replaceMacros(project, context);
-
         if (!StringUtils.isEmpty(triggeredStatus)) {
             sb.append(Ghprb.replaceMacros(project, triggeredStatus));
         } else {
@@ -142,17 +134,8 @@ public class GhprbSimpleStatus extends GhprbExtension implements
             }
         }
 
-        String url = Ghprb.replaceMacros(project, statusUrl);
-        if (StringUtils.equals(statusUrl, "--none--")) {
-            url = "";
-        }
-
         String message = sb.toString();
-        try {
-            ghRepository.createCommitStatus(commitSha, state, url, message, context);
-        } catch (IOException e) {
-            throw new GhprbCommitStatusException(e, state, message, prId);
-        }
+        createCommitStatus(project, prId, commitSha, state, ghRepository, message);
     }
 
     @Override
@@ -283,6 +266,33 @@ public class GhprbSimpleStatus extends GhprbExtension implements
             repo.createCommitStatus(sha1, state, url, message, context);
         } catch (IOException e) {
             throw new GhprbCommitStatusException(e, state, message, pullId);
+        }
+    }
+
+    public void createCommitStatus(Job<?, ?> project,
+                                   int prId,
+                                   String commitSha,
+                                   GHCommitState state,
+                                   GHRepository ghRepository,
+                                   String message) throws GhprbCommitStatusException {
+        String statusUrl = getDescriptor().getStatusUrlDefault(this);
+        if (commitStatusContext == "") {
+            commitStatusContext = getDescriptor().getCommitStatusContextDefault(this);
+        }
+
+        String context = Util.fixEmpty(commitStatusContext);
+        context = Ghprb.replaceMacros(project, context);
+
+        String url = Ghprb.replaceMacros(project, statusUrl);
+        // "--none--" means the user does not want a message, "Jenkins" is the default when we don't have a URL.
+        if (StringUtils.equals(statusUrl, "--none--") || StringUtils.equals(statusUrl, "Jenkins")) {
+            url = "";
+        }
+
+        try {
+            ghRepository.createCommitStatus(commitSha, state, url, message, context);
+        } catch (IOException e) {
+            throw new GhprbCommitStatusException(e, state, message, prId);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -45,7 +45,8 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 Joiner.on("\n").join(context.whiteListLabels),
                 context.extensionContext.getExtensions(),
                 context.includedRegions,
-                context.excludedRegions
+                context.excludedRegions,
+                context.reportSuccessIfNotRegion
         );
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -48,6 +48,8 @@ class GhprbTriggerContext implements Context {
 
     String excludedRegions;
 
+    boolean reportSuccessIfNotRegion;
+
     GhprbExtensionContext extensionContext = new GhprbExtensionContext();
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -88,6 +88,10 @@ f.advanced() {
   f.entry(field: "excludedRegions", title: _("Excluded regions")) {
     f.textarea()
   }
+  f.entry(field: "reportSuccessIfNotRegion",
+          title: _("Report success if build is not triggered due to include/exclude region")) {
+    f.checkbox()
+  }
 }
 f.advanced(title: _("Trigger Setup")) {
   f.entry(title: _("Trigger Setup")) {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-reportSuccessIfNotRegion.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-reportSuccessIfNotRegion.html
@@ -1,0 +1,4 @@
+<div>
+    When checked, if this build is <b>not triggered</b> due to include/exclude regions,
+    it will send a successful build notification back to the GitHub PR.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
@@ -43,6 +43,18 @@ public class GhprbSimpleStatusTest extends org.jenkinsci.plugins.ghprb.extension
     }
 
     @Test
+    public void testCreateCommitStatus() throws Exception {
+        given(ghprbPullRequest.getHead()).willReturn("sha");
+
+        GhprbSimpleStatus status = spy(new GhprbSimpleStatus("default"));
+        status.createCommitStatus(trigger.getActualProject(), 1, "sha", GHCommitState.SUCCESS, ghRepository, "msg");
+
+        verify(ghRepository).createCommitStatus(eq("sha"), eq(GHCommitState.SUCCESS), eq(""), eq("msg"), eq("default"));
+        verifyNoMoreInteractions(ghRepository);
+        verifyNoMoreInteractions(ghprbPullRequest);
+    }
+
+    @Test
     public void testMergedMessage() throws Exception {
         String mergedMessage = "Build triggered for merge commit.";
         given(ghprbPullRequest.getHead()).willReturn("sha");


### PR DESCRIPTION
This is a resolution for https://github.com/jenkinsci/ghprb-plugin/issues/630

This introduces a new checkbox after include/exclude sections. It gives you the ability to report `GHCommitState.SUCCESS` status with "Skipped..." message when a build is skipped because it didn't match any include/exclude patterns.

For example, if you have 4 builds but only Java files changed, you might get this output:
![image](https://user-images.githubusercontent.com/723393/36460852-374b57ca-166f-11e8-9998-0ffc60bd5d1c.png)

The title of this PR should work for CHANGELOG entry.
