### PR TITLE
Avoid posting a comment for empty comment files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
@@ -60,9 +60,11 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
                     content = FileUtils.readFileToString(new File(scriptFilePathResolved));
                 }
 
-                msg.append("Build comment file: \n--------------\n");
-                msg.append(content);
-                msg.append("\n--------------\n");
+                if (content.length() > 0) {
+                    msg.append("Build comment file: \n--------------\n");
+                    msg.append(content);
+                    msg.append("\n--------------\n");
+                }
             } catch (IOException e) {
                 msg.append("\n!!! Couldn't read commit file !!!\n");
                 listener.getLogger().println("Couldn't read comment file at " + scriptFilePathResolved);


### PR DESCRIPTION
If the comment file was completely empty it was still read, surrounded
with a header and a footer, and posted as a comment on the pull request.
This is just noise IMHO.

This commit makes it so that the message stays empty if the file was empty.