### PR TITLE
Avoid posting a comment for empty comment files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
@@ -59,7 +59,11 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
                 if (content == null) {
                     content = FileUtils.readFileToString(new File(scriptFilePathResolved));
                 }
-                msg.append(content);
+
+                if (content.length() > 0) {
+                    msg.append(content);
+                }
+
             } catch (IOException e) {
                 msg.append("\n!!! Couldn't read commit file !!!\n");
                 listener.getLogger().println("Couldn't read comment file at " + scriptFilePathResolved);


### PR DESCRIPTION
If the comment file was completely empty it was still read, surrounded
with a header and a footer, and posted as a comment on the pull request.
This is just noise IMHO.

This commit makes it so that the message stays empty if the file was empty.

@Ippo343 @samrocketman FYI this is #647 with the merge conflict solved. Did not have any access to the new origin, therefore cherry-picked it.