### PR TITLE
Use ssl validation for webhook

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -300,7 +300,7 @@ public class GhprbRepository implements Saveable {
                 Map<String, String> config = new HashMap<String, String>();
                 String secret = getSecret();
                 config.put("url", new URL(getHookUrl()).toExternalForm());
-                config.put("insecure_ssl", "1");
+                config.put("insecure_ssl", "0");
                 if (!StringUtils.isEmpty(secret)) {
                     config.put("secret", secret);
                 }


### PR DESCRIPTION
This is a breaking change. So it highly encouraged from github to set
this to "0", therefore going down this way.

This closes #596

@marcokrikke @samrocketman What do you think about this? Should this be configurable?