### PR TITLE
Ignore watched paths on triggered runs.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -522,16 +522,16 @@ public class GhprbPullRequest {
                 LOGGER.log(Level.FINEST, "Trigger only phrase but we are not triggered");
                 shouldRun = false;
             }
+
+            if (shouldRun && !triggered && !containsWatchedPaths(pr)) {
+                LOGGER.log(Level.FINEST, "Pull request contains no watched paths, skipping the build");
+                shouldRun = false;
+            }
             triggered = false; // Once we have decided that we are triggered then the flag should be set to false.
 
             if (!isAllowedTargetBranch()) {
                 LOGGER.log(Level.FINEST, "Branch is not whitelisted or is blacklisted, skipping the build");
                 return;
-            }
-
-            if (shouldRun && !containsWatchedPaths(pr)) {
-                LOGGER.log(Level.FINEST, "Pull request contains no watched paths, skipping the build");
-                shouldRun = false;
             }
 
             if (shouldRun) {


### PR DESCRIPTION
Fixes #678.

Previously, watch paths would be evaluated even when a run was
initiated from a triggering phrase. As a result, it was not possible
to explicitly request a test run when a PR doesn't match the
configured include/exclude paths.