### PR TITLE
Add support for Workflows when loading comment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,25 @@ job('downstreamJob') {
 }
 ```
 
+### Pipeline support
+
+The plugin supports use with the Jenkins pipeline plugin, but pipeline scripts that use the Comment File trigger should ensure that they stash and unstash files appropriately as stages triggered on remote nodes such as containers will be inaccessible unless explicitly transferred to master at the end of a pipeline using similar to the following:
+
+```
+node(myNode) {
+    stage('plan'){
+        sh: "command > outfile.txt"
+        stash name: "my-stash", includes: "outfile.txt"
+    }
+}
+node("master") {
+    unstash "my-stash"
+}
+
+```
+
+If the job is configured appropriately, the contents of outfile.txt will be posted as a comment to the PR.
+
 ### Updates
 
 See [CHANGELOG](CHANGELOG.md)

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,16 @@
             <version>1.25</version>
         </dependency>
         <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-api</artifactId>
+          <version>1.14.2</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-job</artifactId>
+          <version>1.14.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.11</version>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
@@ -54,11 +54,13 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
                 FilePath workspace;
                 FilePath path;
 
+                // On custom pipelines, build will be an instance of WorkflowRun
                 if (build instanceof WorkflowRun) {
                     FlowExecution exec = ((WorkflowRun) build).getExecution();
                     if (exec == null) {
                         listener.getLogger().println("build was instanceof WorkflowRun but executor was null");
                     } else {
+                        // We walk the execution flow as a run can have multiple workspaces
                         FlowGraphWalker w = new FlowGraphWalker(exec);
                         for (FlowNode n : w) {
                             if (n instanceof BlockStartNode) {
@@ -69,6 +71,8 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
                                     listener.getLogger().println("Remote path is " + node + ":" + nodepath + "\n");
 
                                     if (action.getWorkspace() == null) {
+                                        // if the workspace returns null, the workspace either isn't here or it doesn't
+                                        // exist - in that case, we fail over to trying to find the comment file locally.
                                         continue;
                                     }
 
@@ -88,6 +92,7 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
                         }
                     }
                 } else if (build instanceof Build<?, ?>) {
+                    // When using workers on hosts other than master, we simply get the workspace here.
                     workspace = ((Build<?, ?>) build).getWorkspace();
                     path = workspace.child(scriptFilePathResolved);
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
@@ -51,9 +51,6 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
 
             try {
                 String content = null;
-                FilePath workspace;
-                FilePath path;
-
                 // On custom pipelines, build will be an instance of WorkflowRun
                 if (build instanceof WorkflowRun) {
                     FlowExecution exec = ((WorkflowRun) build).getExecution();
@@ -76,7 +73,7 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
                                         continue;
                                     }
 
-                                    path = action.getWorkspace().child(scriptFilePathResolved);
+                                    FilePath path = action.getWorkspace().child(scriptFilePathResolved);
 
                                     if (path.exists()) {
                                         content = path.readToString();
@@ -93,8 +90,8 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
                     }
                 } else if (build instanceof Build<?, ?>) {
                     // When using workers on hosts other than master, we simply get the workspace here.
-                    workspace = ((Build<?, ?>) build).getWorkspace();
-                    path = workspace.child(scriptFilePathResolved);
+                    FilePath workspace = ((Build<?, ?>) build).getWorkspace();
+                    FilePath path = workspace.child(scriptFilePathResolved);
 
                     if (path.exists()) {
                         content = path.readToString();

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
@@ -11,7 +11,16 @@ import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbExtensionDescriptor;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbProjectExtension;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
+
 import org.kohsuke.stapler.DataBoundConstructor;
+
 
 import java.io.File;
 import java.io.IOException;
@@ -42,9 +51,45 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
 
             try {
                 String content = null;
-                if (build instanceof Build<?, ?>) {
-                    final FilePath workspace = ((Build<?, ?>) build).getWorkspace();
-                    final FilePath path = workspace.child(scriptFilePathResolved);
+                FilePath workspace;
+                FilePath path;
+
+                if (build instanceof WorkflowRun) {
+                    FlowExecution exec = ((WorkflowRun) build).getExecution();
+                    if (exec == null) {
+                        listener.getLogger().println("build was instanceof WorkflowRun but executor was null");
+                    } else {
+                        FlowGraphWalker w = new FlowGraphWalker(exec);
+                        for (FlowNode n : w) {
+                            if (n instanceof BlockStartNode) {
+                                WorkspaceAction action = n.getAction(WorkspaceAction.class);
+                                if (action != null) {
+                                    String node = action.getNode().toString();
+                                    String nodepath = action.getPath().toString();
+                                    listener.getLogger().println("Remote path is " + node + ":" + nodepath + "\n");
+
+                                    if (action.getWorkspace() == null) {
+                                        continue;
+                                    }
+
+                                    path = action.getWorkspace().child(scriptFilePathResolved);
+
+                                    if (path.exists()) {
+                                        content = path.readToString();
+                                    } else {
+                                        listener.getLogger().println(
+                                          "Didn't find comment file in workspace at " + path.absolutize().getRemote()
+                                          + ", falling back to file operations on master.\n"
+                                        );
+                                    }
+
+                                }
+                            }
+                        }
+                    }
+                } else if (build instanceof Build<?, ?>) {
+                    workspace = ((Build<?, ?>) build).getWorkspace();
+                    path = workspace.child(scriptFilePathResolved);
 
                     if (path.exists()) {
                         content = path.readToString();


### PR DESCRIPTION
When a job is initiated via the pipeline plugin, the Run object is no longer an instance of Build, it becomes an instance of WorkflowRun. This means that the current logic for finding comment files on remote workers does not find the comment file when using a pipeline. Additionally, WorkflowRuns are more complex objects and they can have multiple associated workspaces. 

This PR introduces support for finding the files on the remote workspaces. 

This change does *not* allow for seamless discovery of the files in workspaces if multiple nodes are used, and users will be required to `stash` and `unstash` as is appropriate if using remote nodes, but I've included a documentation note to explain this.