### PR TITLE
All a [skip trigger] in comments to not trigger a build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -627,6 +627,11 @@ public class GhprbPullRequest {
                 shouldRun = true;
                 triggered = true;
             }
+            // No matter what, if the skip trigger phrase is in the comment, do not run the build:
+            if (body.contains("[skip trigger]")) {
+              LOGGER.log(Level.FINEST, "comment contains skip trigger, so not doing build.", sender);
+              shouldRun = false;
+            }
         }
 
         if (shouldRun) {


### PR DESCRIPTION
Allows a way to add a special trigger in a PR comment to NOT trigger a build.

For example, let say you have these triggers:
> Jenkins, retest this please
> Jenkins, approve migrations
> Jenkins, run integration tests

If someone has any of those strings in the text, it will trigger a PR check.

But lets say you want to tell someone in a PR comment that those are the all the triggers that they can use.  If you add a comment saying that those are the triggers, it will kick off all those builds! doh!

This fix allows you to say things like:
=============
Hey developer!  There are all the trigger strings you can use:
> Jenkins, retest this please
> Jenkins, approve migrations
> Jenkins, run integration tests
> [skip trigger] (Used by a Jenkins Bot only)
=============
Since I added "[skip trigger]" in the comment, those builds will not get kicked off :)
