### PR TITLE
add an option to disable SSL certificate verification in GitHub webhooks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -10,6 +10,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.SaveableListener;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommentAppender;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbCommitStatusException;
@@ -51,6 +52,9 @@ public class GhprbRepository implements Saveable {
     private static final transient Logger LOGGER = Logger.getLogger(GhprbRepository.class.getName());
 
     private static final transient EnumSet<GHEvent> HOOK_EVENTS = EnumSet.of(GHEvent.ISSUE_COMMENT, GHEvent.PULL_REQUEST);
+
+    private static final transient boolean INSECURE_WEBHOOKS = SystemProperties.getBoolean(
+            GhprbRepository.class.getName() + ".webhook.insecure", false);
 
     private final String reponame;
 
@@ -300,7 +304,7 @@ public class GhprbRepository implements Saveable {
                 Map<String, String> config = new HashMap<String, String>();
                 String secret = getSecret();
                 config.put("url", new URL(getHookUrl()).toExternalForm());
-                config.put("insecure_ssl", "0");
+                config.put("insecure_ssl", INSECURE_WEBHOOKS ? "1" : "0");
                 if (!StringUtils.isEmpty(secret)) {
                     config.put("secret", secret);
                 }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
@@ -3,6 +3,10 @@
 	and will try to create a GitHub hook. Creating a GitHub hook requires that the user
 	which is specified in the <em>GitHub Pull Request Builder</em> configuration has
 	admin rights to the specified repository.<br/>
+	By default, GitHub hooks created this way will have SSL certificate verification enabled.
+	To disable SSL certificate verification in these GitHub hooks, start Jenkins with system
+	property <code>org.jenkinsci.plugins.ghprb.GhprbRepository.webhook.insecure</code> set
+	to <code>true</code>.<br/>
 	If you want to create a hook manually set it for event types:
 		<code>issue_comment</code>,	<code>pull_request</code>
 	and url <code>< your jenkins server url >/ghprbhook/</code>.  The url should be composed of your full jenkins server url plus


### PR DESCRIPTION
When a system property `jenkins.ghprb.webhook.insecure` is set to `true`,
GitHub webhooks created by GHPRB will have SSL certificate verification
disabled. This is useful in case the Jenkins server is available via HTTPS
with a self-signed or corporate CA issued certificate.

Resolves #694