### PR TITLE
Skip default parameters that are null, to avoid NPE when building Environment

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -483,7 +483,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         ParametersDefinitionProperty pdp = this.job.getProperty(ParametersDefinitionProperty.class);
         if (pdp != null) {
             for (ParameterDefinition pd : pdp.getParameterDefinitions()) {
-                values.add(pd.getDefaultParameterValue());
+                if (pd.getDefaultParameterValue() != null) {
+                    values.add(pd.getDefaultParameterValue());
+                }
             }
         }
         return values;


### PR DESCRIPTION
When a Jenkins job has a parameter of a type that doesn't have a default value, the GHPRB plugin will throw a NullPointerException.

The declaration of `hudson.model.ParameterDefinition.getDefaultParameterValue()` explicitly allows null as a possible value by having the` @CheckForNull` annotation.

Such a parameter will result in `null` being added to the the list returned by `GhprbTrigger.getDefaultParameters()`, which is then stored in the `GhprbParametersAction`, which in turn will trigger an NPE when the environment is build.

Here the full stacktrace:

    java.lang.NullPointerException
        at org.jenkinsci.plugins.ghprb.GhprbParametersAction$GhprbAdditionalParameterEnvironmentContributor.buildEnvironmentFor(GhprbParametersAction.java:64)
        at hudson.model.Run.getEnvironment(Run.java:2361)
        at org.jenkinsci.plugins.workflow.job.WorkflowRun.getEnvironment(WorkflowRun.java:512)
        at com.continental.jenkinsci.plugin.scm.DevGateSCM.checkout(DevGateSCM.java:511)
        at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:113)
        at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:85)
        at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:75)
        at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
        at hudson.security.ACL.impersonate(ACL.java:290)
        at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)