### PR TITLE
Cancel downstream builds if was triggered by GHPRB.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -17,6 +17,7 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
+import hudson.model.Cause.UpstreamCause;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Result;
@@ -405,6 +406,27 @@ public class Ghprb {
             return null;
         }
         return (GhprbCause) cause;
+    }
+
+    /**
+    * Return a GhprbCause if the build is a downstream build that has been trigger
+    * by Ghprb plugin
+    * @param build to validate
+    * @return ghprbCause
+    */
+    public static GhprbCause isDownstreamBuild(Run<?, ?> build) {
+        Cause cause = build.getCause(UpstreamCause.class);
+        if (cause == null) {
+            return null;
+        }
+
+        UpstreamCause upstreamCause = (UpstreamCause) cause;
+        for (Cause itemCause: upstreamCause.getUpstreamCauses()) {
+            if (itemCause instanceof GhprbCause) {
+                return (GhprbCause) cause;
+            }
+        }
+        return null;
     }
 
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
@@ -85,10 +85,17 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
             if (!run.isBuilding() && !run.hasntStartedYet()) {
                 break;
             }
+
             GhprbCause cause = Ghprb.getCause(run);
             if (cause == null) {
-                continue;
+                // Validate that if the build is triggered by a GHPRB build and
+                // if so update the cause to stop also this build.
+                cause = Ghprb.isDownstreamBuild(run);
+                if (cause == null) {
+                    continue;
+                }
             }
+
             if (cause.getPullID() == prId) {
                 try {
                     LOGGER.log(


### PR DESCRIPTION
On the situation where a build trigger a new async builds, if any user updates
the PR only one build will be cancel, the upstream one.

When downstreams jobs take a lot to run, the CI is block with builds taht does
not make sense to have running at all.

With this change, each build is validated if the cause is a `UpstreamCause` and
if it is true, this validates that the parent build was triggered by GHPRB, if
so will be cancel if the PR id match.


- I didn't found where the CancelOnUpdates is tested, I'm happy to add a test,
  but I would need a bit of help.

- I'm not sure about adding things to Changelog, the version in Changelog in
  1.41, but releases in Github is 1.42, happy to update also that, but need
  some insights. 