### PR TITLE
GhprbCancelBuildsOnUpdate loops through queue items

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
@@ -18,6 +18,7 @@ import org.jenkinsci.plugins.ghprb.extensions.GhprbGlobalExtension;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbProjectExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -53,26 +54,28 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
         );
 
         Queue queue = Jenkins.getInstance().getQueue();
-        Queue.Item[] queueItems = queue.getItems();
-        for (Queue.Item queueItem : queueItems) {
-            GhprbCause qcause = null;
+        Queue.Item item = project.getQueueItem();
+        if (item != null) {
+            List<Queue.Item> queueItems = queue.getItems(item.task);
+            for (Queue.Item queueItem : queueItems) {
+                GhprbCause qcause = null;
 
-            for (Cause cause : queueItem.getCauses()) {
-                if (cause instanceof GhprbCause) {
-                    qcause = (GhprbCause) cause;
+                for (Cause cause : queueItem.getCauses()) {
+                    if (cause instanceof GhprbCause) {
+                        qcause = (GhprbCause) cause;
+                    }
                 }
-            }
-
-            if (qcause != null && qcause.getPullID() == prId) {
-                try {
-                    LOGGER.log(
-                            Level.FINER,
-                            "Cancelling queued build of " + project.getName() + " for PR # "
-                                    + qcause.getPullID() + ", checking for queued items to cancel."
-                    );
-                    queue.cancel(queueItem);
-                } catch (Exception e) {
-                    LOGGER.log(Level.SEVERE, "Unable to cancel queued build", e);
+                if (qcause != null && qcause.getPullID() == prId) {
+                    try {
+                        LOGGER.log(
+                                Level.FINER,
+                                "Cancelling queued build of " + project.getName() + " for PR # "
+                                        + qcause.getPullID() + ", checking for queued items to cancel."
+                        );
+                        queue.cancel(queueItem);
+                    } catch (Exception e) {
+                        LOGGER.log(Level.SEVERE, "Unable to cancel queued build", e);
+                    }
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
@@ -40,7 +40,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
         return overrideGlobal == null ? Boolean.valueOf(false) : overrideGlobal;
     }
 
-    private void cancelCurrentBuilds(Job<?, ?> project,
+    protected void cancelCurrentBuilds(Job<?, ?> project,
                                      Integer prId) {
         if (getOverrideGlobal()) {
             return;
@@ -53,8 +53,8 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
         );
 
         Queue queue = Jenkins.getInstance().getQueue();
-        Queue.Item queueItem = project.getQueueItem();
-        while (queueItem != null) {
+        Queue.Item[] queueItems = queue.getItems();
+        for (Queue.Item queueItem : queueItems) {
             GhprbCause qcause = null;
 
             for (Cause cause : queueItem.getCauses()) {
@@ -75,8 +75,6 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
                     LOGGER.log(Level.SEVERE, "Unable to cancel queued build", e);
                 }
             }
-
-            queueItem = project.getQueueItem();
         }
 
         LOGGER.log(Level.FINER, "New build scheduled for " + project.getName() + " on PR # " + prId);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdateTest.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.ghprb.extensions.build;
+
+import hudson.model.FreeStyleProject;
+import org.jenkinsci.plugins.ghprb.GhprbITBaseTestCase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GhprbCancelBuildsOnUpdateTest extends GhprbITBaseTestCase {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    private FreeStyleProject project;
+
+    private GhprbCancelBuildsOnUpdate gcbou;
+
+    @Before
+    public void setUp() throws Exception {
+        project = jenkinsRule.getInstance().createProject(FreeStyleProject.class, "FSPRJ");
+
+        Map<String, Object> config = new HashMap<>(1);
+
+        super.beforeTest(config, null, project);
+
+        given(ghprbPullRequest.getPullRequestAuthor()).willReturn(ghUser);
+
+        gcbou = new GhprbCancelBuildsOnUpdate(false);
+    }
+
+    @Test
+    public void testCancelCurrentBuilds() {
+        builds.build(ghprbPullRequest, ghUser, "");
+        gcbou.cancelCurrentBuilds(project, 1);
+    }
+}


### PR DESCRIPTION
The `GhprbCancelBuildsOnUpdate`'s `cancelCurrentBuilds` does not loop through the project's queue items which will cause an infinite loop when new scheduled builds are added. In certain cases the newly scheduled jobs using Ghprb will get caught in the loop and will deadlock the executor and worker threads. See the stacktrace below. 

```
Executor #0 for <Redacted>: executing job #284
"Executor #0 for <Redacted> : executing job #284" Id=46759 Group=main BLOCKED on org.jenkinsci.plugins.ghprb.GhprbPullRequest@71a5579b owned by "Thread-3400" Id=45802
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.setPullRequest(GhprbPullRequest.java:836)
	-  blocked on org.jenkinsci.plugins.ghprb.GhprbPullRequest@71a5579b
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.getPullRequest(GhprbPullRequest.java:827)
	at org.jenkinsci.plugins.ghprb.GhprbBuilds.onStarted(GhprbBuilds.java:112)
	at org.jenkinsci.plugins.ghprb.GhprbBuildListener.onStarted(GhprbBuildListener.java:20)
	at hudson.model.listeners.RunListener.fireStarted(RunListener.java:240)
	at hudson.model.Run.execute(Run.java:1794)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)

Thread-3400
"Thread-3400" Id=45802 Group=main RUNNABLE
	at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1042)
	at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1042)
	at org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate.cancelCurrentBuilds(GhprbCancelBuildsOnUpdate.java:60)
	at org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate.onScheduleBuild(GhprbCancelBuildsOnUpdate.java:114)
	at org.jenkinsci.plugins.ghprb.GhprbTrigger.scheduleBuild(GhprbTrigger.java:379)
	at org.jenkinsci.plugins.ghprb.GhprbBuilds.build(GhprbBuilds.java:94)
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.build(GhprbPullRequest.java:555)
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.tryBuild(GhprbPullRequest.java:548)
	-  locked org.jenkinsci.plugins.ghprb.GhprbPullRequest@71a5579b
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.check(GhprbPullRequest.java:226)
	at org.jenkinsci.plugins.ghprb.GhprbRepository.onPullRequestHook(GhprbRepository.java:394)
	at org.jenkinsci.plugins.ghprb.GhprbTrigger.handlePR(GhprbTrigger.java:746)
	at org.jenkinsci.plugins.ghprb.GhprbRootAction$2.run(GhprbRootAction.java:257)

Thread-3476
"Thread-3476" Id=46485 Group=main BLOCKED on org.jenkinsci.plugins.ghprb.GhprbPullRequest@71a5579b owned by "Thread-3400" Id=45802
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.updatePR(GhprbPullRequest.java:346)
	-  blocked on org.jenkinsci.plugins.ghprb.GhprbPullRequest@71a5579b
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.check(GhprbPullRequest.java:221)
	at org.jenkinsci.plugins.ghprb.GhprbRepository.onPullRequestHook(GhprbRepository.java:394)
	at org.jenkinsci.plugins.ghprb.GhprbTrigger.handlePR(GhprbTrigger.java:746)
	at org.jenkinsci.plugins.ghprb.GhprbRootAction$2.run(GhprbRootAction.java:257)

Thread-3533
"Thread-3533" Id=47105 Group=main BLOCKED on org.jenkinsci.plugins.ghprb.GhprbPullRequest@71a5579b owned by "Thread-3400" Id=45802
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.updatePR(GhprbPullRequest.java:346)
	-  blocked on org.jenkinsci.plugins.ghprb.GhprbPullRequest@71a5579b
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.check(GhprbPullRequest.java:221)
	at org.jenkinsci.plugins.ghprb.GhprbRepository.onPullRequestHook(GhprbRepository.java:394)
	at org.jenkinsci.plugins.ghprb.GhprbTrigger.handlePR(GhprbTrigger.java:746)
	at org.jenkinsci.plugins.ghprb.GhprbRootAction$2.run(GhprbRootAction.java:257)
```

This patches the looping logic to iterate through all the items and exits the loop. 