### PR TITLE
update to support breaking change in github-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This Jenkins plugin builds pull requests from GitHub and will report the results directly to the pull request via
 the [GitHub Commit Status API](http://developer.github.com/v3/repos/statuses/)
 
-When a new pull request is opened in the project and the author of the pull 
+When a new pull request is opened in the project and the author of the pull
 request isn't whitelisted, builder will ask `Can one of the
 admins verify this patch?`. One of the admins can comment `ok to test`
 to accept this pull request for testing, `test this please` for one time

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This Jenkins plugin builds pull requests from GitHub and will report the results directly to the pull request via
 the [GitHub Commit Status API](http://developer.github.com/v3/repos/statuses/)
 
-When a new pull request is opened in the project and the author of the pull
+When a new pull request is opened in the project and the author of the pull 
 request isn't whitelisted, builder will ask `Can one of the
 admins verify this patch?`. One of the admins can comment `ok to test`
 to accept this pull request for testing, `test this please` for one time

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -43,7 +43,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
 
@@ -78,12 +78,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.6.3</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>symbol-annotation</artifactId>
-            <version>1.20</version>
+            <version>1.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
@@ -93,12 +93,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.66</version>
+            <version>1.25</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.12</version>
+            <version>2.4.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -120,48 +120,33 @@
             <artifactId>bouncycastle-api</artifactId>
             <version>2.16.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.61</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
-        </dependency>
 
         <!-- end added dependencies because of maven enforcer plugin -->
 
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.29.5</version>
+            <version>1.27.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.14</version>
+            <version>1.11</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.109</version>
+            <version>1.92</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>4.2.2</version>
+            <version>3.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.77</version>
+            <version>1.63</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -197,7 +182,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.12</version>
+            <version>2.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -209,17 +194,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.5</version>
+            <version>2.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.7</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.20</version>
+            <version>1.9</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,12 +78,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.1.0</version>
+            <version>2.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>symbol-annotation</artifactId>
-            <version>1.9</version>
+            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
@@ -93,12 +93,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.25</version>
+            <version>1.66</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.11</version>
+            <version>2.4.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -119,6 +119,21 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>bouncycastle-api</artifactId>
             <version>2.16.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.61</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
         </dependency>
 
         <!-- end added dependencies because of maven enforcer plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2</version>
+        <version>3.57</version>
         <relativePath />
     </parent>
 
@@ -126,12 +126,12 @@
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.27.0</version>
+            <version>1.29.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.11</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -141,12 +141,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.3.1</version>
+            <version>4.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.63</version>
+            <version>1.77</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.1</version>
+            <version>2.12</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -194,17 +194,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.14</version>
+            <version>2.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.4</version>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.9</version>
+            <version>1.20</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -719,7 +719,7 @@ public class GhprbPullRequest {
         String authorRepoGitUrl = "";
 
         if (prHead != null && prHead.getRepository() != null) {
-            authorRepoGitUrl = prHead.getRepository().gitHttpTransportUrl();
+            authorRepoGitUrl = prHead.getRepository().getHttpTransportUrl();
         }
         return authorRepoGitUrl;
     }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
@@ -218,7 +218,7 @@ public class GhprbPullRequestTest {
         // GIVEN
         String expectedAuthorRepoGitUrl = "https://github.com/jenkinsci/ghprb-plugin";
         GHRepository repository = mock(GHRepository.class);
-        given(repository.gitHttpTransportUrl()).willReturn(expectedAuthorRepoGitUrl);
+        given(repository.getHttpTransportUrl()).willReturn(expectedAuthorRepoGitUrl);
 
         given(head.getRepository()).willReturn(repository);
 


### PR DESCRIPTION
The method gitHttpTransportUrl has been removed from github-api (see commit https://github.com/github-api/github-api/commit/944d92bbb408dc7be91fcbe539a21762c6e0491a?diff=split). And because of that the ghprb plugin is broken. This change correct the issue.