### PR TITLE
Update to use github-api 1.114.2

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -75,11 +75,15 @@
     <!--   <property name="fileExtensions" value="java"/> -->
     <!-- </module> -->
 
-    <module name="SuppressionCommentFilter"/>
+    <module name="LineLength">
+        <property name="max" value="140" />
+    </module>
 
     <module name="TreeWalker">
 
-        <module name="FileContentsHolder"/>
+        <module name="SuppressionCommentFilter"/>
+
+        <!--        <module name="FileContentsHolder"/>-->
 
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
@@ -116,9 +120,6 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="140" />
-        </module>
         <module name="MethodLength"/>
 
         <!-- Checks for whitespace                               -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <workflow.version>1.4</workflow.version>
         <jenkins.version>2.164.3</jenkins.version>
-        <powermock.version>1.6.2</powermock.version>
+        <powermock.version>1.7.4</powermock.version>
         <java.level>8</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
         <checkstyle.version>8.33</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <workflow.version>1.4</workflow.version>
         <jenkins.version>2.164.3</jenkins.version>
         <powermock.version>1.7.4</powermock.version>
         <java.level>8</java.level>
@@ -79,12 +78,11 @@
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.27.0</version>
+            <version>1.31.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.11</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -94,12 +92,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.63</version>
+            <version>1.77</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -135,7 +132,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -147,52 +143,31 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.9</version>
         </dependency>
     </dependencies>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.164.x</artifactId>
+                <version>9</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
 
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>scm-api</artifactId>
-                <version>2.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>symbol-annotation</artifactId>
-                <version>1.9</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>annotation-indexer</artifactId>
-                <version>1.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>script-security</artifactId>
-                <version>1.25</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.9</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>2.4.12</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -287,13 +262,7 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
-        <repository>
-            <id>jgit-repository</id>
-            <name>Eclipse JGit Repository</name>
-            <url>http://download.eclipse.org/jgit/maven</url>
-        </repository>
     </repositories>
-
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
 
@@ -51,12 +51,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <workflow.version>1.4</workflow.version>
-        <jenkins.version>2.7</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <powermock.version>1.6.2</powermock.version>
-        <java.level>7</java.level>
+        <java.level>8</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
-        <checkstyle.version>6.7</checkstyle.version>
-        <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
+        <checkstyle.version>8.33</checkstyle.version>
+        <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
+        <!-- this plugin use jenkins.utils.SystemProperties, which is marked "NoExternalUse" -->
+        <!-- See https://issues.jenkins-ci.org/browse/JENKINS-52704 -->
+        <access-modifier-checker.skip>true</access-modifier-checker.skip>
     </properties>
 
     <!--
@@ -73,56 +76,6 @@
 
     <dependencies>
 
-        <!-- added dependencies because of maven enforcer plugin -->
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>2.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>symbol-annotation</artifactId>
-            <version>1.9</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.12</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>script-security</artifactId>
-            <version>1.25</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.11</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.9.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>3.0.10</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-classworlds</artifactId>
-            <version>2.4.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>bouncycastle-api</artifactId>
-            <version>2.16.1</version>
-        </dependency>
-
-        <!-- end added dependencies because of maven enforcer plugin -->
-
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
@@ -136,7 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.92</version>
+            <version>1.114.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -152,7 +105,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -208,17 +161,58 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>scm-api</artifactId>
+                <version>2.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>symbol-annotation</artifactId>
+                <version>1.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>annotation-indexer</artifactId>
+                <version>1.12</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1.25</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.12</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
+                <version>3.0.0-M4</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
                         <artifactId>surefire-junit47</artifactId>
-                        <version>2.16</version>
+                        <version>3.0.0-M4</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -255,15 +249,6 @@
                         <version>1.9.1</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -132,7 +132,6 @@ public class Ghprb {
         Set<String> authors = getBlacklistedCommitAuthors();
         authors.remove("");
 
-        Map<Pattern, String> skipPatterns = new HashMap<Pattern, String>();
         for (String s : authors) {
             s = s.trim();
             if (compilePattern(s).matcher(author).matches()) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -7,6 +7,7 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
+import hudson.plugins.git.Revision;
 import hudson.plugins.git.util.BuildData;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.ghprb.extensions.GhprbBuildStep;
@@ -186,7 +187,8 @@ public class GhprbBuilds {
         // having two of them, and because the one we added isn't correct
         // @see GhprbTrigger
         for (BuildData data : build.getActions(BuildData.class)) {
-            if (data.getLastBuiltRevision() != null && !data.getLastBuiltRevision().getSha1String().equals(c.getCommit())) {
+            final Revision revision = data.getLastBuiltRevision();
+            if (revision != null && !revision.getSha1String().equals(c.getCommit())) {
                 build.getActions().remove(data);
                 break;
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
@@ -152,7 +152,7 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
                             new Object[] {localSignature, expected});
                     return false;
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 LOGGER.log(Level.SEVERE, "Couldn't match both signatures");
                 return false;
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
@@ -172,7 +172,7 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
     private static GitHubBuilder getBuilder(Item context, String serverAPIUrl, String credentialsId) {
         GitHubBuilder builder = new GitHubBuilder()
                 .withEndpoint(serverAPIUrl)
-                .withConnector(new HttpConnectorWithJenkinsProxy());
+                .withConnector(new HttpConnectorWithJenkinsProxy(serverAPIUrl));
         String contextName = context == null ? "(Jenkins.instance)" : context.getFullDisplayName();
 
         if (StringUtils.isEmpty(credentialsId)) {
@@ -285,7 +285,7 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
 
                 GitHubBuilder builder = new GitHubBuilder()
                         .withEndpoint(serverAPIUrl)
-                        .withConnector(new HttpConnectorWithJenkinsProxy());
+                        .withConnector(new HttpConnectorWithJenkinsProxy(serverAPIUrl));
 
                 if (StringUtils.isEmpty(credentialsId)) {
                     if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -110,7 +110,8 @@ public class GhprbPullRequestMerge extends Recorder implements SimpleBuildStep {
     ) throws InterruptedException, IOException {
         listener = taskListener;
         Job<?, ?> project = run.getParent();
-        if (run.getResult().isWorseThan(Result.SUCCESS)) {
+        Result result = run.getResult();
+        if (result != null && result.isWorseThan(Result.SUCCESS)) {
             listener.getLogger().println("Build did not succeed, merge will not be run");
             return;
         }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -101,7 +101,7 @@ public class GhprbRepository implements Saveable {
         }
 
         try {
-            if (gitHub.getRateLimit().remaining == 0) {
+            if (gitHub.getRateLimit().getRemaining() == 0) {
                 LOGGER.log(Level.INFO, "Exceeded rate limit for repository");
                 return false;
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/HttpConnectorWithJenkinsProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/HttpConnectorWithJenkinsProxy.java
@@ -1,28 +1,55 @@
 package org.jenkinsci.plugins.ghprb;
 
-import hudson.ProxyConfiguration;
-import org.kohsuke.github.HttpConnector;
+import jenkins.model.Jenkins;
+import jenkins.util.JenkinsJVM;
+import okhttp3.OkHttpClient;
+import org.kohsuke.github.extras.okhttp3.OkHttpConnector;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import javax.annotation.Nonnull;
+import java.net.Proxy;
+import java.util.concurrent.TimeUnit;
 
-public class HttpConnectorWithJenkinsProxy implements HttpConnector {
+public class HttpConnectorWithJenkinsProxy extends OkHttpConnector {
+
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 10000;
 
     private static final int DEFAULT_READ_TIMEOUT = 10000;
 
-    public HttpURLConnection connect(URL url) throws IOException {
-        HttpURLConnection con = (HttpURLConnection) ProxyConfiguration.open(url);
+    // Create a default base client with our default connect timeouts
+    private static final OkHttpClient BASECLIENT = new OkHttpClient().newBuilder()
+        .connectTimeout(DEFAULT_CONNECT_TIMEOUT, TimeUnit.MILLISECONDS)
+        .readTimeout(DEFAULT_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+        .build();
 
-        // Set default timeouts in case there are none
-        if (con.getConnectTimeout() == 0) {
-            con.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT);
+    public HttpConnectorWithJenkinsProxy(String host) {
+        super(getClient(host));
+    }
+
+    private static OkHttpClient getClient(String host) {
+        OkHttpClient.Builder builder = BASECLIENT.newBuilder();
+
+        if (JenkinsJVM.isJenkinsJVM()) {
+            builder.proxy(getProxy(host));
         }
-        if (con.getReadTimeout() == 0) {
-            con.setReadTimeout(DEFAULT_READ_TIMEOUT);
+
+        return builder.build();
+    }
+
+    /**
+     * Uses proxy if configured on pluginManager/advanced page
+     *
+     * @param host GitHub's hostname to build proxy to
+     *
+     * @return proxy to use it in connector. Should not be null as it can lead to unexpected behaviour
+     */
+    @Nonnull
+    private static Proxy getProxy(@Nonnull String host) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null || jenkins.proxy == null) {
+            return Proxy.NO_PROXY;
+        } else {
+            return jenkins.proxy.createProxy(host);
         }
-        return con;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.ghprb.extensions.build;
 
 import hudson.Extension;
 import hudson.model.Cause;
+import hudson.model.Executor;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Result;
@@ -98,7 +99,10 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
                                     + project.getName() + " for PR # " + cause.getPullID()
                     );
                     run.addAction(this);
-                    run.getExecutor().interrupt(Result.ABORTED);
+                    Executor executor = run.getExecutor();
+                    if (executor != null) {
+                        executor.interrupt(Result.ABORTED);
+                    }
                 } catch (Exception e) {
                     LOGGER.log(Level.SEVERE, "Error while trying to interrupt build!", e);
                 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/comments/GhprbCommentFile.java
@@ -15,6 +15,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppender, GhprbProjectExtension {
     @Extension
@@ -35,15 +36,15 @@ public class GhprbCommentFile extends GhprbExtension implements GhprbCommentAppe
         return false;
     }
 
-    public String postBuildComment(Run<?, ?> build, TaskListener listener) {
+    public String postBuildComment(final Run<?, ?> build, TaskListener listener) {
         StringBuilder msg = new StringBuilder();
         if (commentFilePath != null && !commentFilePath.isEmpty()) {
-            String scriptFilePathResolved = Ghprb.replaceMacros(build, listener, commentFilePath);
-
+            final String scriptFilePathResolved = Objects.requireNonNull(Ghprb.replaceMacros(build, listener, commentFilePath));
             try {
                 String content = null;
                 if (build instanceof Build<?, ?>) {
                     final FilePath workspace = ((Build<?, ?>) build).getWorkspace();
+                    assert workspace != null;
                     final FilePath path = workspace.child(scriptFilePathResolved);
 
                     if (path.exists()) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -124,7 +124,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements
         }
 
         String statusUrl = getDescriptor().getStatusUrlDefault(this);
-        if (commitStatusContext == "") {
+        if ("".equals(commitStatusContext)) {
             commitStatusContext = getDescriptor().getCommitStatusContextDefault(this);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -300,19 +300,19 @@ class GhprbTriggerContext implements Context {
     }
 
     public void includedRegions(Iterable<String> regions) {
-        String includedRegionsStr = "";
+        StringBuilder builder = new StringBuilder();
         for (String region : regions) {
-            includedRegionsStr += (region + "\n");
+            builder.append(region).append("\n");
         }
-        includedRegions(includedRegionsStr);
+        includedRegions(builder.toString());
     }
 
     public void excludedRegions(Iterable<String> regions) {
-        String excludedRegionsStr = "";
+        StringBuilder builder = new StringBuilder();
         for (String region : regions) {
-            excludedRegionsStr += (region + "\n");
+            builder.append(region).append("\n");
         }
-        excludedRegions(excludedRegionsStr);
+        excludedRegions(builder.toString());
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
@@ -88,7 +88,8 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
 
         if (build.getResult() != Result.UNSTABLE) {
             sb.append("<h2>Build result: ");
-            sb.append(build.getResult().toString());
+            Result result = build.getResult();
+            sb.append(result == null ? "None" : result.toString());
             sb.append("</span></h2>");
 
             try {

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -6,7 +6,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.ParameterValue;
 import hudson.model.Run;
 import net.sf.json.JSONObject;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,7 +19,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -89,12 +92,17 @@ public class GhprbIT extends GhprbITBaseTestCase {
     @Test
     public void shouldBuildTriggersOnUpdatingRetestMessagePR() throws Exception {
         // GIVEN
-        given(ghPullRequest.getCreatedAt()).willReturn(new DateTime().toDate());
+        given(ghPullRequest.getCreatedAt()).willReturn(Date.from(
+                ZonedDateTime.now(ZoneOffset.UTC)
+                    .toInstant()));
         GhprbTestUtil.triggerRunAndWait(10, trigger, project);
         assertThat(project.getBuilds().toArray().length).isEqualTo(1);
 
         given(comment.getBody()).willReturn("retest this please");
-        given(comment.getUpdatedAt()).willReturn(new DateTime().plusDays(1).toDate());
+        given(comment.getUpdatedAt()).willReturn(Date.from(
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .plus(1, ChronoUnit.DAYS)
+                        .toInstant()));
         given(comment.getUser()).willReturn(ghUser);
 
         given(ghPullRequest.getComments()).willReturn(newArrayList(comment));
@@ -111,7 +119,10 @@ public class GhprbIT extends GhprbITBaseTestCase {
         given(commitPointer.getSha()).willReturn("sha");
 
         given(comment.getBody()).willReturn("retest this please");
-        given(comment.getUpdatedAt()).willReturn(new DateTime().plusDays(1).toDate());
+        given(comment.getUpdatedAt()).willReturn(Date.from(
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .plus(1, ChronoUnit.DAYS)
+                        .toInstant()));
         given(comment.getUser()).willReturn(ghUser);
         given(ghPullRequest.getComments()).willReturn(newArrayList(comment));
         given(ghPullRequest.getNumber()).willReturn(5);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
@@ -54,7 +54,8 @@ public abstract class GhprbITBaseTestCase {
 
     protected GhprbTrigger trigger;
 
-    protected GHRateLimit ghRateLimit = new GHRateLimit();
+    @Mock
+    protected GHRateLimit ghRateLimit;
 
     protected void beforeTest(
             Map<String, Object> globalConfig,
@@ -88,7 +89,8 @@ public abstract class GhprbITBaseTestCase {
         given(ghUser.getEmail()).willReturn("email@email.com");
         given(ghUser.getLogin()).willReturn("user");
 
-        ghRateLimit.remaining = GhprbTestUtil.INITIAL_RATE_LIMIT;
+
+        given(ghRateLimit.getRemaining()).willReturn(GhprbTestUtil.INITIAL_RATE_LIMIT);
 
         GhprbTestUtil.mockCommitList(ghPullRequest);
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
@@ -5,7 +5,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitSCM;
-import org.joda.time.DateTime;
 import org.kohsuke.github.GHCommitPointer;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
@@ -16,6 +15,9 @@ import org.kohsuke.github.GitHub;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -79,7 +81,11 @@ public abstract class GhprbITBaseTestCase {
 
         given(ghRepository.getName()).willReturn("dropwizard");
 
-        GhprbTestUtil.mockPR(ghPullRequest, commitPointer, new DateTime(), new DateTime().plusDays(1));
+        GhprbTestUtil.mockPR(ghPullRequest,
+                commitPointer,
+                ZonedDateTime.now(ZoneOffset.UTC),
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .plus(1, ChronoUnit.DAYS));
 
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN)))
                 .willReturn(newArrayList(ghPullRequest))

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -9,7 +9,6 @@ import hudson.util.Secret;
 import org.apache.commons.codec.binary.Hex;
 import org.fest.util.Collections;
 import org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,6 +37,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -519,8 +521,14 @@ public class GhprbRepositoryTest {
         mockCommitList();
         GhprbBuilds builds = mockBuilds();
 
-        Date later = new DateTime().plusHours(3).toDate();
-        Date tomorrow = new DateTime().plusDays(1).toDate();
+        Date later = Date.from(
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .plus(3, ChronoUnit.HOURS)
+                        .toInstant());
+        Date tomorrow = Date.from(
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .plus(1, ChronoUnit.DAYS)
+                        .toInstant());
 
 
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
@@ -616,8 +624,13 @@ public class GhprbRepositoryTest {
     public void testCheckMethodWhenPrWasUpdatedWithRetestPhrase() throws Exception {
         // GIVEN
         List<GHPullRequest> ghPullRequests = createListWithMockPR();
-        Date now = new Date();
-        Date tomorrow = new DateTime().plusDays(1).toDate();
+        Date now = Date.from(
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .toInstant());
+        Date tomorrow = Date.from(
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .plus(1, ChronoUnit.DAYS)
+                        .toInstant());
 
         mockHeadAndBase();
         mockCommitList();

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -759,7 +759,8 @@ public class GhprbRepositoryTest {
     public void testExceedRateLimit() throws Exception {
         // GIVEN
         getNewTrigger();
-        rateLimit.remaining = 0;
+
+        given(rateLimit.getRemaining()).willReturn(0);
         verify(gt, times(1)).getRateLimit();
 
         // WHEN

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.ghprb;
 import com.coravy.hudson.plugins.github.GithubProjectProperty;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.git.GitSCM;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +27,9 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URLEncoder;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.fest.assertions.Assertions.assertThat;
@@ -79,7 +81,11 @@ public class GhprbRootActionTest {
         given(commitPointer.getRef()).willReturn("ref");
         given(ghRepository.getName()).willReturn("dropwizard");
 
-        GhprbTestUtil.mockPR(ghPullRequest, commitPointer, new DateTime(), new DateTime().plusDays(1));
+        GhprbTestUtil.mockPR(ghPullRequest,
+                commitPointer,
+                ZonedDateTime.now(ZoneOffset.UTC),
+                ZonedDateTime.now(ZoneOffset.UTC)
+                        .plus(1, ChronoUnit.DAYS));
 
         given(ghRepository.getPullRequests(eq(OPEN))).willReturn(newArrayList(ghPullRequest)).willReturn(newArrayList(ghPullRequest));
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -20,7 +20,6 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.joda.time.DateTime;
 import org.kohsuke.github.GHCommitPointer;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRateLimit;
@@ -39,7 +38,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -253,7 +254,7 @@ public final class GhprbTestUtil {
         Mockito.when(itr.hasNext()).thenReturn(false);
     }
 
-    public static void mockPR(GHPullRequest prToMock, GHCommitPointer commitPointer, DateTime... updatedDate) throws Exception {
+    public static void mockPR(GHPullRequest prToMock, GHCommitPointer commitPointer, ZonedDateTime... updatedDate) throws Exception {
 
         given(prToMock.getHead()).willReturn(commitPointer);
         given(prToMock.getBase()).willReturn(commitPointer);
@@ -262,13 +263,13 @@ public final class GhprbTestUtil {
 
         if (updatedDate.length > 1) {
             given(prToMock.getUpdatedAt())
-                    .willReturn(updatedDate[0].toDate())
-                    .willReturn(updatedDate[0].toDate())
-                    .willReturn(updatedDate[1].toDate())
-                    .willReturn(updatedDate[1].toDate())
-                    .willReturn(updatedDate[1].toDate());
+                    .willReturn(Date.from(updatedDate[0].toInstant()))
+                    .willReturn(Date.from(updatedDate[0].toInstant()))
+                    .willReturn(Date.from(updatedDate[1].toInstant()))
+                    .willReturn(Date.from(updatedDate[1].toInstant()))
+                    .willReturn(Date.from(updatedDate[1].toInstant()));
         } else {
-            given(prToMock.getUpdatedAt()).willReturn(updatedDate[0].toDate());
+            given(prToMock.getUpdatedAt()).willReturn(Date.from(updatedDate[0].toInstant()));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -422,8 +422,9 @@ public final class GhprbTestUtil {
 
         GhprbTrigger trigger = spy(req.bindJSON(GhprbTrigger.class, defaults));
 
-        GHRateLimit limit = new GHRateLimit();
-        limit.remaining = INITIAL_RATE_LIMIT;
+
+        GHRateLimit limit = Mockito.mock(GHRateLimit.class);
+        given(limit.getRemaining()).willReturn(INITIAL_RATE_LIMIT);
 
         GitHub github = Mockito.mock(GitHub.class);
         given(github.getRateLimit()).willReturn(limit);


### PR DESCRIPTION
This includes a number of fixes and other tweaks to get the project building and running against the new gitub-api and Jenkins 2.164.3.

Supersedes #767 - checkstyle update
Supersedes #775 - moves to plugin-pom 4.3 and bom 
Supersedes #768 - https basically already there
