### PR TITLE
Ghprb reponds to requests outside of it's hook path

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRootActionTest.java
@@ -130,6 +130,7 @@ public class GhprbRootActionTest {
         given(req.getHeader("X-GitHub-Event")).willReturn("issue_comment");
         given(req.getReader()).willReturn(br);
         given(req.getCharacterEncoding()).willReturn("UTF-8");
+        given(req.getPathInfo()).willReturn("/ghprbhook/");
 
 
         StringReader brTest = new StringReader(GhprbTestUtil.PAYLOAD);
@@ -158,6 +159,73 @@ public class GhprbRootActionTest {
 
         assertThat(project.getBuilds().toArray().length).isEqualTo(1);
     }
+
+    @Test
+    public void wrongPathIsNotHandled() throws Exception {
+        // GIVEN
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject("wrongPathIsNotHandled");
+
+        doReturn(project).when(trigger).getActualProject();
+        doReturn(true).when(trigger).getUseGitHubHooks();
+
+        given(commitPointer.getSha()).willReturn("sha1");
+        GhprbTestUtil.setupGhprbTriggerDescriptor(null);
+        project.addProperty(new GithubProjectProperty("https://github.com/user/dropwizard"));
+        given(ghPullRequest.getId()).willReturn((long) prId);
+        given(ghPullRequest.getNumber()).willReturn(prId);
+        given(ghRepository.getPullRequest(prId)).willReturn(ghPullRequest);
+        Ghprb ghprb = spy(new Ghprb(trigger));
+        doReturn(ghprbGitHub).when(ghprb).getGitHub();
+        doReturn(true).when(ghprb).isAdmin(Mockito.any(GHUser.class));
+
+        trigger.start(project, true);
+        trigger.setHelper(ghprb);
+
+        project.addTrigger(trigger);
+        GitSCM scm = GhprbTestUtil.provideGitSCM();
+        project.setScm(scm);
+
+        GhprbTestUtil.triggerRunAndWait(10, trigger, project);
+
+        assertThat(project.getBuilds().toArray().length).isEqualTo(0);
+
+        BufferedReader br = new BufferedReader(new StringReader(
+                "payload=" + URLEncoder.encode(GhprbTestUtil.PAYLOAD, "UTF-8")));
+
+
+        given(req.getContentType()).willReturn("application/x-www-form-urlencoded");
+        given(req.getParameter("payload")).willReturn(GhprbTestUtil.PAYLOAD);
+        given(req.getHeader("X-GitHub-Event")).willReturn("issue_comment");
+        given(req.getReader()).willReturn(br);
+        given(req.getCharacterEncoding()).willReturn("UTF-8");
+        given(req.getPathInfo()).willReturn("/github-webhook/");
+
+        StringReader brTest = new StringReader(GhprbTestUtil.PAYLOAD);
+
+        IssueComment issueComment = spy(GitHub.connectAnonymously().parseEventPayload(brTest, IssueComment.class));
+        brTest.close();
+
+        GHIssueComment ghIssueComment = spy(issueComment.getComment());
+
+        Mockito.when(issueComment.getComment()).thenReturn(ghIssueComment);
+        Mockito.doReturn(ghUser).when(ghIssueComment).getUser();
+
+
+        given(trigger.getGitHub().parseEventPayload(Mockito.any(Reader.class), Mockito.eq(IssueComment.class))).willReturn(issueComment);
+
+        GhprbRootAction ra = new GhprbRootAction();
+        ra.doIndex(req, null);
+        // handles race condition around starting and finishing builds. Give the system time
+        // to finish indexing, create a build, queue it, and run it.
+        int count = 0;
+        while (count < 5 && project.getBuilds().toArray().length == 0) {
+            GhprbTestUtil.waitForBuildsToFinish(project);
+            Thread.sleep(50);
+            count = count + 1;
+        }
+
+        assertThat(project.getBuilds().toArray().length).isEqualTo(0);
+     }
 
     @Test
     public void disabledJobsDontBuild() throws Exception {
@@ -194,6 +262,7 @@ public class GhprbRootActionTest {
         given(req.getHeader("X-GitHub-Event")).willReturn("issue_comment");
         given(req.getReader()).willReturn(br);
         given(req.getCharacterEncoding()).willReturn("UTF-8");
+        given(req.getPathInfo()).willReturn("/ghprbhook/");
 
         GhprbRootAction ra = new GhprbRootAction();
         ra.doIndex(req, null);
@@ -206,6 +275,7 @@ public class GhprbRootActionTest {
     public void testJson() throws Exception {
         given(req.getContentType()).willReturn("application/json");
         given(req.getHeader("X-GitHub-Event")).willReturn("issue_comment");
+        given(req.getPathInfo()).willReturn("/ghprbhook/");
 
         // convert String into InputStream
         InputStream is = new ByteArrayInputStream(GhprbTestUtil.PAYLOAD.getBytes());


### PR DESCRIPTION
I do not have a fix as of yet, just a test case illustrating the problem. This is in relation to jenkinsci/pipeline-github-plugin#84.

The issue is that where one might have some github hooks coming into ghprb, and some into an unrelated endpoint, the ghprb handler is intercepting requests it simply should not be.

I'm 90% sure doIndex in GhprbRootAction just needs to check the path if it's not the correct one, somehow yield the request back to the router for handling. This is the part I am unclear on, what the correct way to do that is in terms of the stapler framework. 

Perhaps someone could point me in the right direction and I can supply a fix as well?

