### PR TITLE
Do not cache the GitHub client

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
@@ -72,8 +72,6 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
 
     private final Secret secret;
 
-    private transient GitHub gh;
-
     @DataBoundConstructor
     public GhprbGitHubAuth(
             String serverAPIUrl,
@@ -200,27 +198,24 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
         return builder;
     }
 
-    private void buildConnection(Item context) {
+    private GitHub buildConnection(Item context) {
         GitHubBuilder builder = getBuilder(context, serverAPIUrl, credentialsId);
         if (builder == null) {
             LOGGER.log(Level.SEVERE, "Unable to get builder using credentials: {0}", credentialsId);
-            return;
+            return null;
         }
+
         try {
-            gh = builder.build();
+            return builder.build();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Unable to connect using credentials: " + credentialsId, e);
         }
+
+        return null;
     }
 
     public GitHub getConnection(Item context) throws IOException {
-        synchronized (this) {
-            if (gh == null) {
-                buildConnection(context);
-            }
-
-            return gh;
-        }
+        return buildConnection(context);
     }
 
     @Override


### PR DESCRIPTION
Caching the GitHub client has the unfortunate side effect of caching the
credentials too. This prevents GHRP from effectively using Github App
credentials as the returned credentials expire after an hour. By
returning a new GitHub client on demand, the credentials are fresh for
each action and generally last long enough for most, if not, all GHRP
tasks.

I'm not sure if this is the best approach, but it seems to work fine.

A seemingly better approach would be to use `AuthorizationProvider`s available in newer versions of the Github API plugin. However, it seems this would mean that GHRP would need to depend on the Github Branch Source Plugin to use Github App credentials and its associated auth provider.

I completely understand if this is an unacceptable change, but it would be nice to support Github App authentication as it avoids needed to create a bot user account and provides fine grained permissions.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
