### PR TITLE
check if commit author is blacklisted before checking if they are whitelisted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -126,20 +126,23 @@ public class Ghprb {
      * Checks for skip build commit author.
      *
      * @param author The GitHub commit author
-     * @return the skip sender or null if should not skip
+     * @return is author in black list
      */
-    public String checkBlackListCommitAuthor(String author) {
+    public boolean checkBlackListCommitAuthor(String author) {
         Set<String> authors = getBlacklistedCommitAuthors();
         authors.remove("");
 
         Map<Pattern, String> skipPatterns = new HashMap<Pattern, String>();
+        String result = null;
         for (String s : authors) {
             s = s.trim();
             if (compilePattern(s).matcher(author).matches()) {
-                return s;
+                result = s;
+                break;
             }
         }
-        return null;
+
+        return !StringUtils.isEmpty(result);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -359,7 +359,7 @@ public class GhprbPullRequest {
 
                 // the author of the PR could have been whitelisted since its creation
                 GHUser pullRequestAuthor = getPullRequestAuthor();
-                if (!accepted && helper.isWhitelisted(pullRequestAuthor)) {
+                if (!accepted && !helper.checkBlackListCommitAuthor(pullRequestAuthor.getLogin()) && helper.isWhitelisted(pullRequestAuthor)) {
                     LOGGER.log(Level.INFO, "Pull request #{0}'s author has been whitelisted", new Object[] {id});
                     setAccepted(false);
                 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -285,11 +285,12 @@ public class GhprbPullRequest {
             if (commitAuthor == null) {
                 return;
             }
-            String blackListCommitAuthor = helper.checkBlackListCommitAuthor(commitAuthor.getName());
-            if (!StringUtils.isEmpty(blackListCommitAuthor)) {
+            String author = commitAuthor.getName();
+            boolean blackListCommitAuthor = helper.checkBlackListCommitAuthor(author);
+            if (blackListCommitAuthor) {
                 LOGGER.log(Level.FINE,
                         "Pull request triggered by user: {0}. Skipping build because that user is blacklisted.",
-                        blackListCommitAuthor);
+                        author);
                 shouldRun = false;
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -358,7 +358,8 @@ public class GhprbPullRequest {
                 GHPullRequest pullRequest = getPullRequest();
 
                 // the author of the PR could have been whitelisted since its creation
-                if (!accepted && helper.isWhitelisted(getPullRequestAuthor())) {
+                GHUser pullRequestAuthor = getPullRequestAuthor();
+                if (!accepted && helper.isWhitelisted(pullRequestAuthor)) {
                     LOGGER.log(Level.INFO, "Pull request #{0}'s author has been whitelisted", new Object[] {id});
                     setAccepted(false);
                 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -359,7 +359,8 @@ public class GhprbPullRequest {
 
                 // the author of the PR could have been whitelisted since its creation
                 GHUser pullRequestAuthor = getPullRequestAuthor();
-                if (!accepted && !helper.checkBlackListCommitAuthor(pullRequestAuthor.getLogin()) && helper.isWhitelisted(pullRequestAuthor)) {
+                String pullRequestAuthorName = pullRequestAuthor.getLogin();
+                if (!accepted && !helper.checkBlackListCommitAuthor(pullRequestAuthorName) && helper.isWhitelisted(pullRequestAuthor)) {
                     LOGGER.log(Level.INFO, "Pull request #{0}'s author has been whitelisted", new Object[] {id});
                     setAccepted(false);
                 }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -222,7 +222,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getHead();
         verify(ghPullRequest, times(2)).getNumber();
         verify(ghPullRequest, times(1)).getUpdatedAt();
-        verify(ghPullRequest, times(1)).getUser();
+        verify(ghPullRequest, times(2)).getUser();
         verify(ghPullRequest, times(2)).getBase();
         verify(ghPullRequest, times(1)).getComments();
         verify(ghPullRequest, times(1)).listCommits();
@@ -239,6 +239,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(gt);
 
         verify(ghUser, times(1)).getName();
+        verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
         verifyZeroInteractions(ghUser);
     }
@@ -290,7 +291,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(3)).getUser();
+        verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(6)).getBase();
@@ -318,7 +319,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
-        verify(ghUser, times(1)).getLogin();
+        verify(ghUser, times(3)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
 
@@ -471,7 +472,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(3)).getUser();
+        verify(ghPullRequest, times(5)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(6)).getBase();
@@ -499,7 +500,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
-        verify(ghUser, times(1)).getLogin();
+        verify(ghUser, times(3)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
 
@@ -563,7 +564,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(5)).getUser();
+        verify(ghPullRequest, times(7)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(6)).getBase();
@@ -599,7 +600,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(4)).getLogin();
         verify(ghUser, times(3)).getName();
         verifyNoMoreInteractions(ghUser);
     }
@@ -665,7 +666,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(5)).getUser();
+        verify(ghPullRequest, times(7)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(9)).getHead();
         verify(ghPullRequest, times(7)).getBase();
@@ -701,7 +702,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(4)).getLogin();
         verify(ghUser, times(2)).getName();
         verifyNoMoreInteractions(ghUser);
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTriggerTest.java
@@ -183,12 +183,12 @@ public class GhprbTriggerTest {
         prHelper.set(pr, helper);
 
         given(helper.getBlacklistedCommitAuthors()).willReturn(new HashSet<String>(Arrays.asList("bot1", "bot2")));
-        given(helper.checkBlackListCommitAuthor(user.getName())).willReturn(null);
+        given(helper.checkBlackListCommitAuthor(user.getName())).willReturn(false);
         shouldRun.set(pr, true);
         checkSkip.invoke(pr);
         assertThat(shouldRun.get(pr)).isEqualTo(true);
 
-        given(helper.checkBlackListCommitAuthor(user.getName())).willReturn("bot2");
+        given(helper.checkBlackListCommitAuthor(user.getName())).willReturn(true);
         shouldRun.set(pr, true);
         checkSkip.invoke(pr);
         assertThat(shouldRun.get(pr)).isEqualTo(false);


### PR DESCRIPTION
this PR is an implementation proposal to prevent cases like #831 by adding known users to the list of committers to skip (introduced in #488).
if the PR author is in the deny list, they will never be checked for org membership.

this will prevent the api call that returns 404 and will prevent rate limit.

internal reference: https://issues.redhat.com/browse/APPSRE-4423