### PR TITLE
Deprecate GitHub Pull Request Builder plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This Jenkins plugin builds pull requests from GitHub and will report the results directly to the pull request via
 the [GitHub Commit Status API](http://developer.github.com/v3/repos/statuses/)
 
+## Deprecated
+
+This plugin is **deprecated**. It has been replaced by the [GitHub Branch Source Plugin](https://plugins.jenkins.io/github-branch-source/). It has known security vulnerabilities and is no longer being maintained. Users should migrate to the [GitHub Branch Source Plugin](https://plugins.jenkins.io/github-branch-source/).
+
+## Deprecated
+
 When a new pull request is opened in the project and the author of the pull
 request isn't whitelisted, builder will ask `Can one of the
 admins verify this patch?`. One of the admins can comment `ok to test`


### PR DESCRIPTION
## Deprecate GitHub Pull Request Builder plugin

The GitHub Pull Request Builder plugin should be deprecated so that users do not mistakenly install it when integrating with GitHub.

More details are available in Jenkins infrastructure help desk ticket:

* https://github.com/jenkins-infra/helpdesk/issues/4608

The documentation for plugins.jenkins.io is being updated at:

* https://github.com/jenkins-infra/plugins-wiki-docs/pull/8

The deprecation message is being added here as one more location that declares the plugin is deprecated.

### Testing done

Confirmed that the page looks correct in its other implementation in:

* https://github.com/jenkins-infra/plugins-wiki-docs/pull/8

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
